### PR TITLE
refactor reclaim

### DIFF
--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -373,7 +373,7 @@ func (jc *jobCache) deleteJob(job *apis.JobInfo) {
 }
 
 func (jc *jobCache) retryDeleteJob(job *apis.JobInfo) {
-	klog.V(3).Infof("Retry to delete Job <%v/%v>",
+	klog.V(4).Infof("Retry to delete Job <%v/%v>",
 		job.Namespace, job.Name)
 
 	jc.deletedJobs.AddRateLimited(job)

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -152,6 +152,7 @@ func (alloc *Action) allocateResources(queues *util.PriorityQueue, jobsMap map[a
 		}
 
 		job := jobs.Pop().(*api.JobInfo)
+		klog.V(3).Infof("[poolside] Scheduling job %s", job.Name)
 		if _, found = pendingTasks[job.UID]; !found {
 			tasks := util.NewPriorityQueue(ssn.TaskOrderFn)
 			for _, task := range job.TaskStatusIndex[api.Pending] {

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -441,12 +441,12 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 	}
 
 	if ssn.JobReady(job) {
-		klog.V(3).InfoS("Job ready, return statement", "jobName", job.UID)
+		klog.V(3).InfoS("[poolside] Job ready, return statement", "jobName", job.UID)
 		updateJobAllocatedHyperNode(job, jobNewAllocatedHyperNode)
 		return stmt
 	} else {
 		if !ssn.JobPipelined(job) {
-			klog.V(3).InfoS("cannot find free capacity for job", "job", string(job.Queue)+"/"+string(job.UID))
+			klog.V(3).InfoS("[poolside] cannot find free capacity for job", "job", string(job.Queue)+"/"+string(job.UID))
 			stmt.Discard()
 		}
 		return nil

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -370,7 +370,7 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 
 		// check if the task with its spec has already predicates failed
 		if job.TaskHasFitErrors(task) {
-			klog.V(3).Infof("Task %s with role spec %s has already predicated failed, skip", task.Name, task.TaskRole)
+			klog.V(4).Infof("Task %s with role spec %s has already predicated failed, skip", task.Name, task.TaskRole)
 			continue
 		}
 

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -446,6 +446,7 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 		return stmt
 	} else {
 		if !ssn.JobPipelined(job) {
+			klog.V(3).InfoS("cannot find free capacity for job", "job", string(job.Queue)+"/"+string(job.UID))
 			stmt.Discard()
 		}
 		return nil

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -364,13 +364,13 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 	for !tasks.Empty() {
 		task := tasks.Pop().(*api.TaskInfo)
 		if !ssn.Allocatable(queue, task) {
-			klog.V(4).Infof("Queue <%s> is overused when considering task <%s>, ignore it.", queue.Name, task.Name)
+			klog.V(3).Infof("Queue <%s> is overused when considering task <%s/%s>, ignore it.", queue.Name, task.Job, task.Name)
 			continue
 		}
 
 		// check if the task with its spec has already predicates failed
 		if job.TaskHasFitErrors(task) {
-			klog.V(5).Infof("Task %s with role spec %s has already predicated failed, skip", task.Name, task.TaskRole)
+			klog.V(3).Infof("Task %s with role spec %s has already predicated failed, skip", task.Name, task.TaskRole)
 			continue
 		}
 
@@ -549,7 +549,7 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *api.TaskInfo, node *api.NodeInfo, job *api.JobInfo) (err error) {
 	// Allocate idle resource to the task.
 	if task.InitResreq.LessEqual(node.Idle, api.Zero) {
-		klog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)
+		klog.V(3).Infof("Binding Task <%s/%s/%s> to node <%v>", job.Queue, task.Job, task.Name, node.Name)
 		if err = stmt.Allocate(task, node); err != nil {
 			klog.Errorf("Failed to bind Task %v on %v in Session %v, err: %v",
 				task.UID, node.Name, alloc.session.UID, err)

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -78,7 +78,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 
 	alloc.session = ssn
 	alloc.pickUpQueuesAndJobs(queues, jobsMap)
-	klog.V(3).Infof("Try to allocate resource to %d Queues", len(jobsMap))
+	klog.V(4).Infof("Try to allocate resource to %d Queues", len(jobsMap))
 	alloc.allocateResources(queues, jobsMap)
 }
 
@@ -363,7 +363,7 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 	for !tasks.Empty() {
 		task := tasks.Pop().(*api.TaskInfo)
 		if !ssn.Allocatable(queue, task) {
-			klog.V(3).Infof("Queue <%s> is overused when considering task <%s>, ignore it.", queue.Name, task.Name)
+			klog.V(4).Infof("Queue <%s> is overused when considering task <%s>, ignore it.", queue.Name, task.Name)
 			continue
 		}
 
@@ -373,7 +373,7 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 			continue
 		}
 
-		klog.V(3).Infof("There are <%d> nodes for Job <%v/%v>", len(ssn.Nodes), job.Namespace, job.Name)
+		klog.V(4).Infof("There are <%d> nodes for Job <%v/%v>", len(ssn.Nodes), job.Namespace, job.Name)
 
 		if err := ssn.PrePredicateFn(task); err != nil {
 			klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
@@ -563,7 +563,7 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 		return
 	}
 
-	klog.V(3).Infof("Predicates failed in allocate for task <%s/%s> on node <%s> with limited resources",
+	klog.V(4).Infof("Predicates failed in allocate for task <%s/%s> on node <%s> with limited resources",
 		task.Namespace, task.Name, node.Name)
 
 	// Allocate releasing resource to the task if any.

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -319,7 +319,7 @@ func (pmpt *Action) normalPreempt(
 	assigned := false
 
 	for _, node := range selectedNodes {
-		klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.",
+		klog.V(4).Infof("Considering Task <%s/%s> on Node <%s>.",
 			preemptor.Namespace, preemptor.Name, node.Name)
 
 		var preemptees []*api.TaskInfo
@@ -334,7 +334,7 @@ func (pmpt *Action) normalPreempt(
 		metrics.UpdatePreemptionVictimsCount(len(victims))
 
 		if err := util.ValidateVictims(preemptor, node, victims); err != nil {
-			klog.V(3).Infof("No validated victims on Node <%s>: %v", node.Name, err)
+			klog.V(4).Infof("No validated victims on Node <%s>: %v", node.Name, err)
 			continue
 		}
 
@@ -357,9 +357,13 @@ func (pmpt *Action) normalPreempt(
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
-			klog.V(3).Infof("Try to preempt Task <%s/%s> for Task <%s/%s>",
-				preemptee.Namespace, preemptee.Name, preemptor.Namespace, preemptor.Name)
-			if err := stmt.Evict(preemptee, "preempt"); err != nil {
+			preempteeQueue := preemptee.Namespace
+			preempteeJob := ssn.Jobs[preemptee.Job]
+			if preempteeJob != nil && preempteeJob.Queue != "" {
+				preempteeQueue = string(preempteeJob.Queue)
+			}
+			klog.V(3).Infof("Try to preempt Task <%s/%s> for Task <%s/%s>", preempteeQueue, preemptee.Name, currentQueue.Name, preemptor.Name)
+			if err := stmt.Evict(preemptee, "preempt "); err != nil {
 				klog.Errorf("Failed to preempt Task <%s/%s> for Task <%s/%s>: %v",
 					preemptee.Namespace, preemptee.Name, preemptor.Namespace, preemptor.Name, err)
 				continue
@@ -411,7 +415,7 @@ func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {
 
 		err := pmpt.ssn.PredicateFn(preemptor, nodeInfo)
 		if err == nil {
-			return fmt.Errorf("not eligible due to the pod's nominated node is already schedulable, which should not happen as preemption means no node is schedulable")
+			return fmt.Errorf("not eligible due to the pod's nominated node is already schedulable, which should not happen as preemption means no node is schedulable. %v", err)
 		}
 
 		fitError, ok := err.(*api.FitError)
@@ -720,7 +724,7 @@ func SelectVictimsOnNode(
 	metrics.UpdatePreemptionVictimsCount(len(allVictims))
 
 	if err := util.ValidateVictims(preemptor, nodeInfo, allVictims); err != nil {
-		klog.V(3).Infof("No validated victims on Node <%s>: %v", nodeInfo.Name, err)
+		klog.V(4).Infof("No validated victims on Node <%s>: %v", nodeInfo.Name, err)
 		return nil, api.AsStatus(fmt.Errorf("no validated victims on Node <%s>: %v", nodeInfo.Name, err))
 	}
 

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -206,7 +206,7 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 			// Commit changes only if job is pipelined, otherwise try next job.
 			if ssn.JobPipelined(preemptorJob) {
 				for _, op := range stmt.Operations() {
-					klog.V(3).Infof("Preemptor <%s/%s> committed operation: %+v", preemptorJob.Queue, preemptorJob.Name, op)
+					klog.V(3).Infof("[poolside] Preemptor <%s/%s> committed operation: %s", preemptorJob.Queue, preemptorJob.Name, op.String())
 				}
 				stmt.Commit()
 			} else {
@@ -220,56 +220,56 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 		}
 
 		// Preemption between Task within Job.
-		for _, job := range underRequest {
-			// Fix: preemptor numbers lose when in same job
-			preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
-			for _, task := range job.TaskStatusIndex[api.Pending] {
-				// Again, skip scheduling gated tasks
-				if task.SchGated {
-					continue
-				}
-				preemptorTasks[job.UID].Push(task)
-			}
-			for {
-				if _, found := preemptorTasks[job.UID]; !found {
-					break
-				}
+		// for _, job := range underRequest {
+		// 	// Fix: preemptor numbers lose when in same job
+		// 	preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
+		// 	for _, task := range job.TaskStatusIndex[api.Pending] {
+		// 		// Again, skip scheduling gated tasks
+		// 		if task.SchGated {
+		// 			continue
+		// 		}
+		// 		preemptorTasks[job.UID].Push(task)
+		// 	}
+		// 	for {
+		// 		if _, found := preemptorTasks[job.UID]; !found {
+		// 			break
+		// 		}
 
-				if preemptorTasks[job.UID].Empty() {
-					break
-				}
+		// 		if preemptorTasks[job.UID].Empty() {
+		// 			break
+		// 		}
 
-				preemptor := preemptorTasks[job.UID].Pop().(*api.TaskInfo)
+		// 		preemptor := preemptorTasks[job.UID].Pop().(*api.TaskInfo)
 
-				stmt := framework.NewStatement(ssn)
-				assigned, err := pmpt.preempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
-					// Ignore non running task.
-					if !api.PreemptableStatus(task.Status) {
-						return false
-					}
-					// BestEffort pod is not supported to preempt unBestEffort pod.
-					if preemptor.BestEffort && !task.BestEffort {
-						return false
-					}
-					// should skip not preemptable pod
-					if !task.Preemptable {
-						return false
-					}
+		// 		stmt := framework.NewStatement(ssn)
+		// 		assigned, err := pmpt.preempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
+		// 			// Ignore non running task.
+		// 			if !api.PreemptableStatus(task.Status) {
+		// 				return false
+		// 			}
+		// 			// BestEffort pod is not supported to preempt unBestEffort pod.
+		// 			if preemptor.BestEffort && !task.BestEffort {
+		// 				return false
+		// 			}
+		// 			// should skip not preemptable pod
+		// 			if !task.Preemptable {
+		// 				return false
+		// 			}
 
-					// Preempt tasks within job.
-					return preemptor.Job == task.Job
-				}, ph)
-				if err != nil {
-					klog.V(3).Infof("Preemptor <%s/%s> failed to preempt Task , err: %s", preemptor.Namespace, preemptor.Name, err)
-				}
-				stmt.Commit()
+		// 			// Preempt tasks within job.
+		// 			return preemptor.Job == task.Job
+		// 		}, ph)
+		// 		if err != nil {
+		// 			klog.V(3).Infof("Preemptor <%s/%s> failed to preempt Task , err: %s", preemptor.Namespace, preemptor.Name, err)
+		// 		}
+		// 		stmt.Commit()
 
-				// If no preemption, next job.
-				if !assigned {
-					break
-				}
-			}
-		}
+		// 		// If no preemption, next job.
+		// 		if !assigned {
+		// 			break
+		// 		}
+		// 	}
+		// }
 	}
 }
 

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -171,12 +171,13 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 
 				// If not preemptor tasks, next job.
 				if preemptorTasks[preemptorJob.UID].Empty() {
-					klog.V(3).Infof("No preemptor task in job <%s/%s>.",
+					klog.V(4).Infof("No preemptor task in job <%s/%s>.",
 						preemptorJob.Namespace, preemptorJob.Name)
 					break
 				}
 
 				preemptor := preemptorTasks[preemptorJob.UID].Pop().(*api.TaskInfo)
+				klog.V(3).Infof("Preemptor task <%s/%s/%s>", preemptorJob.Queue, preemptorJob.Name, preemptor.Name)
 
 				assigned, err = pmpt.preempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
 					// Ignore non running task.
@@ -204,6 +205,9 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 
 			// Commit changes only if job is pipelined, otherwise try next job.
 			if ssn.JobPipelined(preemptorJob) {
+				for _, op := range stmt.Operations() {
+					klog.V(3).Infof("Preemptor <%s/%s> committed operation: %+v", preemptorJob.Queue, preemptorJob.Name, op)
+				}
 				stmt.Commit()
 			} else {
 				stmt.Discard()

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -367,7 +367,7 @@ func (pmpt *Action) normalPreempt(
 				preempteeQueue = string(preempteeJob.Queue)
 			}
 			klog.V(3).Infof("Try to preempt Task <%s/%s> for Task <%s/%s>", preempteeQueue, preemptee.Name, currentQueue.Name, preemptor.Name)
-			if err := stmt.Evict(preemptee, "preempt "); err != nil {
+			if err := stmt.Evict(preemptee, fmt.Sprintf("preempt for task <%s/%s>", currentQueue.Name, preemptor.Name)); err != nil {
 				klog.Errorf("Failed to preempt Task <%s/%s> for Task <%s/%s>: %v",
 					preemptee.Namespace, preemptee.Name, preemptor.Namespace, preemptor.Name, err)
 				continue

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -174,7 +174,7 @@ func noBudgetViolationAfterReclaim(ssn *framework.Session, victimJob, pendingJob
 	queueDeservedGPUs := ssn.Queues[victimJob.Queue].GetDeservedGPU()
 
 	withoutVictimJob := int64(0)
-	if len(victimJob.Tasks) == int(victimJob.TaskMinAvailableTotal) {
+	if len(victimJob.Tasks) == int(victimJob.MinAvailable) {
 		// when it's not an elastic workload, we check the total request of the job
 		withoutVictimJob = queueAllocatedGPUs - victimJob.GetTotalRequestGPU()
 	} else {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -76,7 +76,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		// it uses the PreemptiveFn of the capacity plugin to check if the queue can reclaim.
 		// A queue can not reclaim when allocated + job.TotalRequest > deserved.
 		if !ssn.Preemptive(ssn.Queues[pendingJob.Queue], pendingJob) {
-			klog.V(3).Infof("Job <%s/%s> can not reclaim resources due to overusage", pendingJob.Queue, pendingJob.Name)
+			klog.V(3).Infof("[poolside] Job <%s/%s> can not reclaim resources due to overusage", pendingJob.Queue, pendingJob.Name)
 			continue
 		}
 
@@ -162,9 +162,9 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		}
 	}
 	if reclaimedEnough {
-		klog.V(3).Infof("Job <%s/%s> will reclaim enough resources: %v", pendingJob.Queue, pendingJob.Name, finalPendingJobTopology)
+		klog.V(3).Infof("[poolside] Job <%s/%s> will reclaim enough resources: %v", pendingJob.Queue, pendingJob.Name, finalPendingJobTopology)
 	} else {
-		klog.V(3).Infof("Job <%s/%s> cannot reclaim resources due to not enough resources. Considered jobs: %v", pendingJob.Queue, pendingJob.Name, consideredJobs)
+		klog.V(3).Infof("[poolside] Job <%s/%s> cannot reclaim resources due to not enough resources. Considered jobs: %v", pendingJob.Queue, pendingJob.Name, consideredJobs)
 	}
 	return reclaimedEnough, reclaimedGPU, finalPendingJobTopology
 }

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -356,6 +356,8 @@ func preemptorJobOrder(ssn *framework.Session) func(l, r interface{}) bool {
 			return lJob.Priority > rJob.Priority
 		}
 
-		return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
+		// we need to prioritize the job that gets created later
+		// otherwise the new job will just keep evicting jobs but don't get the resource
+		return rJob.CreationTimestamp.Before(&lJob.CreationTimestamp)
 	}
 }

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -23,6 +23,8 @@ limitations under the License.
 package reclaim
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -173,6 +175,14 @@ type EvictTask struct {
 	GPU          int64
 	TasksToEvict []*api.TaskInfo
 	PendingTask  *api.TaskInfo
+}
+
+func (e *EvictTask) String() string {
+	tasks := []string{}
+	for _, t := range e.TasksToEvict {
+		tasks = append(tasks, t.Name)
+	}
+	return fmt.Sprintf("[PendingTask: %s, NodeName: %s, TasksToEvict: %v]", e.PendingTask.Name, e.NodeName, tasks)
 }
 
 func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) map[string]*EvictTask {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -1,4 +1,4 @@
-/*
+*
 Copyright 2018 The Kubernetes Authors.
 Copyright 2018-2025 The Volcano Authors.
 
@@ -23,6 +23,8 @@ limitations under the License.
 package reclaim
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -47,191 +49,308 @@ func (ra *Action) Execute(ssn *framework.Session) {
 	klog.V(5).Infof("Enter Reclaim ...")
 	defer klog.V(5).Infof("Leaving Reclaim ...")
 
-	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
-	queueMap := map[api.QueueID]*api.QueueInfo{}
-
-	preemptorsMap := map[api.QueueID]*util.PriorityQueue{}
-	preemptorTasks := map[api.JobID]*util.PriorityQueue{}
-
-	klog.V(3).Infof("There are <%d> Jobs and <%d> Queues in total for scheduling.",
-		len(ssn.Jobs), len(ssn.Queues))
+	pendingJobs := util.NewPriorityQueue(ssn.PreemptorJobOrderFn)
+	victimJobs := util.NewPriorityQueue(ssn.PreempteeJobOrderFn)
 
 	for _, job := range ssn.Jobs {
+		// job.IsPending check if the job has passed the Enqueue phase.
+		// We shouldn't really have any pending job in terms of Volcano here.
 		if job.IsPending() {
 			continue
 		}
-
-		if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
-			klog.V(4).Infof("Job <%s/%s> Queue <%s> skip reclaim, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
-			continue
-		}
-
-		if queue, found := ssn.Queues[job.Queue]; !found {
-			klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>", job.Queue, job.Namespace, job.Name)
-			continue
-		} else if _, existed := queueMap[queue.UID]; !existed {
-			klog.V(4).Infof("Added Queue <%s> for Job <%s/%s>", queue.Name, job.Namespace, job.Name)
-			queueMap[queue.UID] = queue
-			queues.Push(queue)
-		}
-
-		if ssn.JobStarving(job) {
-			if _, found := preemptorsMap[job.Queue]; !found {
-				preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
-			}
-			preemptorsMap[job.Queue].Push(job)
-			preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
-			for _, task := range job.TaskStatusIndex[api.Pending] {
-				if task.SchGated {
-					continue
-				}
-				preemptorTasks[job.UID].Push(task)
-			}
+		// When job is starving, it means the job is pending to scheduled in our terms.
+		if job.IsStarving() {
+			pendingJobs.Push(job)
+		} else {
+			victimJobs.Push(job)
 		}
 	}
 
 	for {
-		// If no queues, break
-		if queues.Empty() {
+		if pendingJobs.Empty() {
 			break
 		}
 
-		var job *api.JobInfo
-		var task *api.TaskInfo
-
-		queue := queues.Pop().(*api.QueueInfo)
-		if ssn.Overused(queue) {
-			klog.V(3).Infof("Queue <%s> is overused, ignore it.", queue.Name)
+		pendingJob := pendingJobs.Pop().(*api.JobInfo)
+		// it uses the PreemptiveFn of the capacity plugin to check if the queue can reclaim.
+		// A queue can not reclaim when allocated + job.TotalRequest > deserved.
+		if !ssn.Preemptive(ssn.Queues[pendingJob.Queue], pendingJob) {
+			klog.V(3).Infof("Job <%s/%s> Queue <%s> can not reclaim resources due to overusage", pendingJob.Namespace, pendingJob.Name, pendingJob.Queue)
 			continue
 		}
 
-		// Found "high" priority job
-		jobs, found := preemptorsMap[queue.UID]
-		if !found || jobs.Empty() {
-			continue
-		} else {
-			job = jobs.Pop().(*api.JobInfo)
-		}
-
-		// Found "high" priority task to reclaim others
-		if tasks, found := preemptorTasks[job.UID]; !found || tasks.Empty() || !ssn.JobStarving(job) {
-			continue
-		} else {
-			task = tasks.Pop().(*api.TaskInfo)
-		}
-
-		if task.Pod.Spec.PreemptionPolicy != nil && *task.Pod.Spec.PreemptionPolicy == v1.PreemptNever {
-			klog.V(3).Infof("Task %s/%s is not eligible to preempt other tasks due to preemptionPolicy is Never", task.Namespace, task.Name)
-			// TODO: In order to avoid blocking other tasks in the job or other jobs in the queue to reclaim resources, the job and queue need
-			// to be pushed back to the priority queue. Need to refactor the framework of reclaim action, see issue: https://github.com/volcano-sh/volcano/issues/3738
-			jobs.Push(job)
-			queues.Push(queue)
+		if !jobPolicyAllowPeemption(pendingJob) {
+			klog.V(3).Infof("Job <%s/%s> Queue <%s> can not reclaim resources due to preemption policy", pendingJob.Namespace, pendingJob.Name, pendingJob.Queue)
 			continue
 		}
 
-		//In allocate action we need check all the ancestor queues' capability but in reclaim action we should just check current queue's capability, and reclaim happens when queue not allocatable so we just need focus on the reclaim here.
-		//So it's more descriptive to user preempt related semantics.
-		if !ssn.Preemptive(queue, task) {
-			klog.V(3).Infof("Queue <%s> can not reclaim by preempt others when considering task <%s> , ignore it.", queue.Name, task.Name)
-			continue
-		}
-
-		if err := ssn.PrePredicateFn(task); err != nil {
-			klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
-			continue
-		}
-
-		assigned := false
-		// we should filter out those nodes that are UnschedulableAndUnresolvable status got in allocate action
-		totalNodes := ssn.FilterOutUnschedulableAndUnresolvableNodesForTask(task)
-		for _, n := range totalNodes {
-			// When filtering candidate nodes, need to consider the node statusSets instead of the err information.
-			// refer to kube-scheduler preemption code: https://github.com/kubernetes/kubernetes/blob/9d87fa215d9e8020abdc17132d1252536cd752d2/pkg/scheduler/framework/preemption/preemption.go#L422
-			if err := ssn.PredicateForPreemptAction(task, n); err != nil {
-				klog.V(4).Infof("Reclaim predicate for task %s/%s on node %s return error %v ", task.Namespace, task.Name, n.Name, err)
-				continue
+		reclaimedResource := api.EmptyResource()
+		reclaimedEnough := false
+		finalVictims := []*api.JobInfo{}
+		for {
+			if reclaimedEnough || victimJobs.Empty() {
+				break
 			}
-
-			klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.", task.Namespace, task.Name, n.Name)
-
-			var reclaimees []*api.TaskInfo
-			for _, task := range n.Tasks {
-				// Ignore non running task.
-				if task.Status != api.Running {
-					continue
-				}
-				if !task.Preemptable {
-					continue
-				}
-
-				if j, found := ssn.Jobs[task.Job]; !found {
-					continue
-				} else if j.Queue != job.Queue {
-					q := ssn.Queues[j.Queue]
-					if !q.Reclaimable() {
-						continue
-					}
-					// Clone task to avoid modify Task's status on node.
-					reclaimees = append(reclaimees, task.Clone())
-				}
-			}
-
-			if len(reclaimees) == 0 {
-				klog.V(4).Infof("No reclaimees on Node <%s>.", n.Name)
-				continue
-			}
-
-			victims := ssn.Reclaimable(task, reclaimees)
-
-			if err := util.ValidateVictims(task, n, victims); err != nil {
-				klog.V(3).Infof("No validated victims on Node <%s>: %v", n.Name, err)
-				continue
-			}
-
-			victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
-
-			resreq := task.InitResreq.Clone()
-			reclaimed := api.EmptyResource()
-
-			// Reclaim victims for tasks.
-			for !victimsQueue.Empty() {
-				reclaimee := victimsQueue.Pop().(*api.TaskInfo)
-				klog.Errorf("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
-					reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
-				if err := ssn.Evict(reclaimee, "reclaim"); err != nil {
-					klog.Errorf("Failed to reclaim Task <%s/%s> for Tasks <%s/%s>: %v",
-						reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name, err)
-					continue
-				}
-				reclaimed.Add(reclaimee.Resreq)
-				// If reclaimed enough resources, break loop to avoid Sub panic.
-				if resreq.LessEqual(reclaimed, api.Zero) {
-					break
-				}
-			}
-
-			klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>.",
-				reclaimed, task.Namespace, task.Name, task.InitResreq)
-
-			if task.InitResreq.LessEqual(reclaimed, api.Zero) {
-				if err := ssn.Pipeline(task, n.Name); err != nil {
-					klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
-						task.Namespace, task.Name, n.Name)
-				}
-
-				// Ignore error of pipeline, will be corrected in next scheduling loop.
-				assigned = true
-
+			victimJob := victimJobs.Pop().(*api.JobInfo)
+			finalVictims = append(finalVictims, victimJob)
+			reclaimedResource.Add(victimJob.TotalRequest)
+			if reclaimedResource.LessEqual(pendingJob.TotalRequest, api.Zero) {
+				reclaimedEnough = true
 				break
 			}
 		}
 
-		if assigned {
-			jobs.Push(job)
+		if !reclaimedEnough {
+			klog.V(3).Infof(`Job <%s/%s> Queue <%s> can not reclaim resources due to not enough resources. 
+			Reclaimed resources: <%v>, requested resources: <%v>`,
+				pendingJob.Namespace, pendingJob.Name, pendingJob.Queue, reclaimedResource, pendingJob.TotalRequest)
+
+			// push back the victims that were not reclaimed
+			for _, victim := range finalVictims {
+				victimJobs.Push(victim)
+			}
+			continue
 		}
-		queues.Push(queue)
+
+		for _, victim := range finalVictims {
+			errs := evictJob(ssn, victim, pendingJob.Name)
+			if len(errs) > 0 {
+				klog.Errorf("Failed to reclaim job <%s/%s> for job <%s/%s>: %v",
+					victim.Namespace, victim.Name, pendingJob.Namespace, pendingJob.Name, errs)
+				continue
+			}
+		}
+
+		// since killing one task in a job terminates the whole job, we try to pipeline the job here
+		if err := ssn.Pipeline(pendingJob, ""); err != nil {
+			klog.Errorf("Failed to pipeline job <%s/%s>: %v", pendingJob.Namespace, pendingJob.Name, err)
+			continue
+		}
 	}
+
+	// queues := util.NewPriorityQueue(ssn.QueueOrderFn)
+	// queueMap := map[api.QueueID]*api.QueueInfo{}
+
+	// preemptorsMap := map[api.QueueID]*util.PriorityQueue{}
+	// preemptorTasks := map[api.JobID]*util.PriorityQueue{}
+	// preempteesMap := map[api.QueueID]*util.PriorityQueue{}
+
+	// klog.V(3).Infof("There are <%d> Jobs and <%d> Queues in total for scheduling.",
+	// 	len(ssn.Jobs), len(ssn.Queues))
+
+	// for _, job := range ssn.Jobs {
+	// 	if job.IsPending() {
+	// 		continue
+	// 	}
+
+	// 	if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
+	// 		klog.V(4).Infof("Job <%s/%s> Queue <%s> skip reclaim, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
+	// 		continue
+	// 	}
+	// 	queue, found := ssn.Queues[job.Queue]
+	// 	if !found {
+	// 		klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>", job.Queue, job.Namespace, job.Name)
+	// 		continue
+	// 	}
+	// 	if _, found := queueMap[queue.UID]; !found {
+	// 		klog.V(4).Infof("Added Queue <%s> for Job <%s/%s>", queue.Name, job.Namespace, job.Name)
+	// 		queueMap[queue.UID] = queue
+	// 		queues.Push(queue)
+	// 	}
+
+	// 	// if it's starving, it means the job is pending for more resources
+	// 	if ssn.JobStarving(job) {
+	// 		if _, found := preemptorsMap[job.Queue]; !found {
+	// 			preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
+	// 		}
+	// 		preemptorsMap[job.Queue].Push(job)
+	// 		preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
+	// 		for _, task := range job.TaskStatusIndex[api.Pending] {
+	// 			if task.SchGated {
+	// 				continue
+	// 			}
+	// 			preemptorTasks[job.UID].Push(task)
+	// 		}
+	// 	} else {
+	// 		if _, found := preempteesMap[job.Queue]; !found {
+	// 			preempteesMap[job.Queue] = util.NewPriorityQueue(VictimJobOrder)
+	// 		}
+	// 		preempteesMap[job.Queue].Push(job)
+	// 	}
+	// }
+
+	// for {
+	// 	// If no queues, break
+	// 	if queues.Empty() {
+	// 		break
+	// 	}
+
+	// 	var job *api.JobInfo
+	// 	var task *api.TaskInfo
+
+	// 	queue := queues.Pop().(*api.QueueInfo)
+	// 	if ssn.Overused(queue) {
+	// 		klog.V(3).Infof("Queue <%s> is overused <%v>, ignore it.", queue.Name, queue.Queue.Status.Allocated)
+	// 		continue
+	// 	}
+
+	// 	// Get all jobs based on the queue and the queue is selected based on the QueueOrderFn on L50
+	// 	jobs, found := preemptorsMap[queue.UID]
+	// 	if !found || jobs.Empty() {
+	// 		continue
+	// 	}
+	// 	// The job is selected based on the JobOrderFn on L80
+	// 	job = jobs.Pop().(*api.JobInfo)
+
+	// 	// TODO: job doesn't have the preemptionPolicy information, so we pop one task to check that for now
+	// 	tasks, found := preemptorTasks[job.UID]
+	// 	if !found || tasks.Empty() {
+	// 		queues.Push(queue)
+	// 		continue
+	// 	}
+	// 	task = tasks.Pop().(*api.TaskInfo)
+	// 	if task.Pod.Spec.PreemptionPolicy != nil && *task.Pod.Spec.PreemptionPolicy == v1.PreemptNever {
+	// 		klog.V(3).Infof("Task %s/%s is not eligible to preempt other tasks due to preemptionPolicy is Never", task.Namespace, task.Name)
+	// 		queues.Push(queue)
+	// 		continue
+	// 	}
+
+	// 	// Here we're mainly using the PreemptiveFn of the capacity plugin to check if the queue can reclaim
+	// 	if !ssn.Preemptive(queue, job) {
+	// 		klog.V(3).Infof("Queue <%s> can not reclaim by evicting others when considering job <%s> , ignore it.", queue.Name, job.Name)
+	// 		continue
+	// 	}
+
+	// 	// TODO: we should use PrePredicateFn to check all tasks in the job
+	// 	if err := ssn.PrePredicateFn(task); err != nil {
+	// 		klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
+	// 		continue
+	// 	}
+
+	// 	assigned := false
+	// 	// we should filter out those nodes that are UnschedulableAndUnresolvable status got in allocate action
+	// 	totalNodes := ssn.FilterOutUnschedulableAndUnresolvableNodesForTask(task)
+	// 	for _, n := range totalNodes {
+	// 		// When filtering candidate nodes, need to consider the node statusSets instead of the err information.
+	// 		// refer to kube-scheduler preemption code: https://github.com/kubernetes/kubernetes/blob/9d87fa215d9e8020abdc17132d1252536cd752d2/pkg/scheduler/framework/preemption/preemption.go#L422
+	// 		if err := ssn.PredicateForPreemptAction(task, n); err != nil {
+	// 			klog.V(4).Infof("Reclaim predicate for task %s/%s on node %s return error %v ", task.Namespace, task.Name, n.Name, err)
+	// 			continue
+	// 		}
+
+	// 		klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.", task.Namespace, task.Name, n.Name)
+
+	// 		var reclaimees []*api.TaskInfo
+	// 		for _, task := range n.Tasks {
+	// 			// Ignore non running task.
+	// 			if task.Status != api.Running {
+	// 				continue
+	// 			}
+	// 			if !task.Preemptable {
+	// 				continue
+	// 			}
+
+	// 			if j, found := ssn.Jobs[task.Job]; !found {
+	// 				continue
+	// 			} else if j.Queue != job.Queue {
+	// 				q := ssn.Queues[j.Queue]
+	// 				if !q.Reclaimable() {
+	// 					continue
+	// 				}
+	// 				// Clone task to avoid modify Task's status on node.
+	// 				reclaimees = append(reclaimees, task.Clone())
+	// 			}
+	// 		}
+
+	// 		if len(reclaimees) == 0 {
+	// 			klog.V(3).Infof("No reclaimees on Node <%s>.", n.Name)
+	// 			continue
+	// 		}
+
+	// 		victims := ssn.Reclaimable(task, reclaimees)
+
+	// 		if err := util.ValidateVictims(task, n, victims); err != nil {
+	// 			klog.V(3).Infof("No validated victims on Node <%s>: %v", n.Name, err)
+	// 			continue
+	// 		}
+
+	// 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
+
+	// 		resreq := task.InitResreq.Clone()
+	// 		reclaimed := n.FutureIdle()
+
+	// 		// Reclaim victims for tasks.
+	// 		for !victimsQueue.Empty() {
+	// 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
+	// 			klog.Errorf("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
+	// 				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
+	// 			if err := ssn.Evict(reclaimee, "reclaim for task "+task.Name); err != nil {
+	// 				klog.Errorf("Failed to reclaim Task <%s/%s> for Tasks <%s/%s>: %v",
+	// 					reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name, err)
+	// 				continue
+	// 			}
+	// 			reclaimed.Add(reclaimee.Resreq)
+	// 			// If reclaimed enough resources, break loop to avoid Sub panic.
+	// 			if resreq.LessEqual(reclaimed, api.Zero) {
+	// 				break
+	// 			}
+	// 		}
+
+	// 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>.",
+	// 			reclaimed, task.Namespace, task.Name, task.InitResreq)
+
+	// 		if task.InitResreq.LessEqual(reclaimed, api.Zero) {
+	// 			if err := ssn.Pipeline(task, n.Name); err != nil {
+	// 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
+	// 					task.Namespace, task.Name, n.Name)
+	// 			}
+
+	// 			// Ignore error of pipeline, will be corrected in next scheduling loop.
+	// 			assigned = true
+
+	// 			break
+	// 		}
+	// 	}
+
+	// 	if assigned {
+	// 		jobs.Push(job)
+	// 	}
+	// 	queues.Push(queue)
+	// }
 }
 
 func (ra *Action) UnInitialize() {
+}
+
+func jobPolicyAllowPeemption(job *api.JobInfo) bool {
+	tasks := job.TaskStatusIndex[api.Pending]
+	for _, task := range tasks {
+		if task.Pod.Spec.PreemptionPolicy != nil && *task.Pod.Spec.PreemptionPolicy == v1.PreemptNever {
+			return false
+		}
+	}
+	return true
+}
+
+// TODO: check if we need to evict all tasks or not because
+// we have TerminateJob
+func evictJob(ssn *framework.Session, victimJob *api.JobInfo, pendingJobName string) []error {
+	numberOfTasksToEvict := len(victimJob.Tasks) - int(victimJob.TaskMinAvailableTotal)
+	if numberOfTasksToEvict <= 0 {
+		numberOfTasksToEvict = len(victimJob.Tasks)
+	}
+	i := 0
+	errors := []error{}
+	// TODO: we should iterate tasks based on node to have better bin packing
+	for _, task := range victimJob.Tasks {
+		err := ssn.Evict(task, "reclaim for job "+pendingJobName)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("failed to evict task <%s/%s>: %v", task.Namespace, task.Name, err))
+		}
+		i++
+		if i >= numberOfTasksToEvict {
+			break
+		}
+	}
+	return errors
 }

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -92,7 +92,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 
 		for _, task := range pendingJobTopology {
 			for _, t := range task.TasksToEvict {
-				err := ssn.Evict(t, "reclaim for job "+pendingJob.Name)
+				err := ssn.Evict(t, "reclaim for job "+string(pendingJob.Queue)+"/"+pendingJob.Name)
 				if err != nil {
 					klog.Errorf("Failed to evict task <%s/%s> for job <%s/%s>: %v",
 						t.Namespace, t.Name, pendingJob.Namespace, pendingJob.Name, err)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -82,7 +82,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue := getReclaimedResources(ssn, pendingJob, runningJobs)
+		reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue := getReclaimedResources(ssn, pendingJob.Clone(), runningJobs)
 		if !reclaimedEnough {
 			klog.V(3).Infof(`Job <%s/%s> Queue <%s> can not reclaim resources due to not enough resources. Reclaimed GPU: <%d>, requested GPUs: <%d>`,
 				pendingJob.Namespace, pendingJob.Name, pendingJob.Queue, reclaimedGPU, pendingJob.GetTotalRequestGPU())
@@ -129,7 +129,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 	reclaimedEnough := false
 	finalVictims := []*api.JobInfo{}
 	skippedVictims := []*api.JobInfo{}
-	pendingJobTopology := map[string]*EvictTask{}
+	finalPendingJobTopology := map[string]*EvictTask{}
 	for {
 		if reclaimedEnough || runningJobs.Empty() {
 			break
@@ -145,16 +145,18 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 			continue
 		}
 		// then we need to check if the node can accommodate the task
-		pendingJobTopology = findNodesForPendingJob(ssn, jobToEvict, pendingJob)
+		pendingJobTopology := findNodesForPendingJob(ssn, jobToEvict, pendingJob)
 		if len(pendingJobTopology) == 0 {
 			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
 
-		finalVictims = append(finalVictims, jobToEvict)
 		for _, n := range pendingJobTopology {
+			finalPendingJobTopology[n.PendingTask.Name] = n
 			reclaimedGPU += n.GPU
 		}
+
+		finalVictims = append(finalVictims, jobToEvict)
 		if reclaimedGPU >= pendingJob.GetTotalRequestGPU() {
 			reclaimedEnough = true
 			break
@@ -166,7 +168,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		// we need to include the final victims because we didn't reclaim enough so they won't be evicted
 		jobsToRequeue = append(jobsToRequeue, finalVictims...)
 	}
-	return reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue
+	return reclaimedEnough, reclaimedGPU, finalPendingJobTopology, jobsToRequeue
 }
 
 func noBudgetViolationAfterReclaim(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) bool {
@@ -248,6 +250,7 @@ func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.J
 				}
 			}
 			pendingJobTopology[task.Name] = result
+			delete(pendingJob.Tasks, task.UID)
 			break
 		}
 	}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -127,6 +127,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 	reclaimedGPU := int64(0)
 	reclaimedEnough := false
 	finalPendingJobTopology := map[string]*EvictTask{}
+	consideredJobs := []string{}
 	for {
 		if reclaimedEnough || runningJobs.Empty() {
 			break
@@ -135,19 +136,19 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		if jobToEvict.Queue == pendingJob.Queue {
 			continue
 		}
-		klog.V(3).Infof("JobToEvict: <%s/%s>", jobToEvict.Queue, jobToEvict.Name)
 		// first we check if the queue is overused
 		if !isQueueOverused(ssn, jobToEvict) {
 			klog.V(3).Infof("Job <%s/%s> can not be evicted because the queue is not overused", jobToEvict.Queue, jobToEvict.Name)
 			continue
 		}
+		klog.V(3).Infof("JobToEvict: <%s/%s>", jobToEvict.Queue, jobToEvict.Name)
+		consideredJobs = append(consideredJobs, fmt.Sprintf("%s/%s", jobToEvict.Queue, jobToEvict.Name))
 		// then we need to check if the node can accommodate the task
 		pendingJobTopology := findNodesForPendingJob(ssn, jobToEvict, pendingJob)
 		if len(pendingJobTopology) == 0 {
 			klog.V(3).Infof("Job <%s/%s> can not be evicted because the node can not accommodate the task", jobToEvict.Queue, jobToEvict.Name)
 			continue
 		}
-		klog.V(3).Infof("Job %s/%s will evict tasks: %v", pendingJob.Queue, pendingJob.Name, pendingJobTopology)
 
 		for _, n := range pendingJobTopology {
 			finalPendingJobTopology[n.PendingTask.Name] = n
@@ -156,10 +157,14 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		}
 
 		if reclaimedGPU >= pendingJob.GetTotalRequestGPU() {
-			klog.V(3).Infof("Job <%s/%s> will reclaim enough resources", pendingJob.Queue, pendingJob.Name)
 			reclaimedEnough = true
 			break
 		}
+	}
+	if reclaimedEnough {
+		klog.V(3).Infof("Job <%s/%s> will reclaim enough resources: %v", pendingJob.Queue, pendingJob.Name, finalPendingJobTopology)
+	} else {
+		klog.V(3).Infof("Job <%s/%s> cannot reclaim resources due to not enough resources. Considered jobs: %v", pendingJob.Queue, pendingJob.Name, consideredJobs)
 	}
 	return reclaimedEnough, reclaimedGPU, finalPendingJobTopology
 }

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -73,24 +73,24 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		// it uses the PreemptiveFn of the capacity plugin to check if the queue can reclaim.
 		// A queue can not reclaim when allocated + job.TotalRequest > deserved.
 		if !ssn.Preemptive(ssn.Queues[pendingJob.Queue], pendingJob) {
-			klog.V(3).Infof("Job <%s/%s> Queue <%s> can not reclaim resources due to overusage", pendingJob.Namespace, pendingJob.Name, pendingJob.Queue)
+			klog.V(3).Infof("Job <%s/%s> can not reclaim resources due to overusage", pendingJob.Queue, pendingJob.Name)
 			continue
 		}
 
 		if !jobPolicyAllowPeemption(pendingJob) {
-			klog.V(3).Infof("Job <%s/%s> Queue <%s> can not reclaim resources due to preemption policy", pendingJob.Namespace, pendingJob.Name, pendingJob.Queue)
+			klog.V(3).Infof("Job <%s/%s> can not reclaim resources due to preemption policy", pendingJob.Queue, pendingJob.Name)
 			continue
 		}
 
 		reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue := getReclaimedResources(ssn, pendingJob.Clone(), runningJobs)
+		// push back the jobs that would not be reclaimed
+		for _, victim := range jobsToRequeue {
+			runningJobs.Push(victim)
+		}
 		if !reclaimedEnough {
-			klog.V(3).Infof(`Job <%s/%s> Queue <%s> can not reclaim resources due to not enough resources. Reclaimed GPU: <%d>, requested GPUs: <%d>`,
-				pendingJob.Namespace, pendingJob.Name, pendingJob.Queue, reclaimedGPU, pendingJob.GetTotalRequestGPU())
+			klog.V(3).Infof(`Job <%s/%s> can not reclaim resources due to not enough resources. Reclaimed GPU: <%d>, requested GPUs: <%d>`,
+				pendingJob.Queue, pendingJob.Name, reclaimedGPU, pendingJob.GetTotalRequestGPU())
 
-			// push back the jobs that would not be reclaimed
-			for _, victim := range jobsToRequeue {
-				runningJobs.Push(victim)
-			}
 			continue
 		}
 
@@ -139,10 +139,10 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
-		klog.V(3).Infof("Checking if job <%s/%s> can be evicted", jobToEvict.Namespace, jobToEvict.Name)
+		klog.V(3).Infof("Checking if job <%s/%s> can be evicted", jobToEvict.Queue, jobToEvict.Name)
 		// first we check if the queue is overused
 		if !isQueueOverused(ssn, jobToEvict) {
-			klog.V(3).Infof("Job <%s/%s> can not be evicted because the queue is not overused", jobToEvict.Namespace, jobToEvict.Name)
+			klog.V(3).Infof("Job <%s/%s> can not be evicted because the queue is not overused", jobToEvict.Queue, jobToEvict.Name)
 			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
@@ -246,10 +246,13 @@ func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.J
 			result := &EvictTask{
 				NodeName:    node.NodeName,
 				PendingTask: task,
-				GPU:         requiredGPU,
+				GPU:         int64(0),
 			}
 			if len(node.TasksToEvict) == 0 {
 				node.GPU -= requiredGPU
+				result.GPU = requiredGPU
+				pendingJobTopology[task.Name] = result
+				delete(pendingJob.Tasks, task.UID)
 				break
 			}
 			for idx, t := range node.TasksToEvict {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -139,8 +139,10 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
-		// first we check if it violates the budget when the victimJob is reclaimed
-		if !noBudgetViolationAfterReclaim(ssn, jobToEvict, pendingJob) {
+		klog.V(3).Infof("Checking if job <%s/%s> can be evicted", jobToEvict.Namespace, jobToEvict.Name)
+		// first we check if the queue is overused
+		if !isQueueOverused(ssn, jobToEvict) {
+			klog.V(3).Infof("Job <%s/%s> can not be evicted because the queue is not overused", jobToEvict.Namespace, jobToEvict.Name)
 			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
@@ -169,6 +171,12 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		jobsToRequeue = append(jobsToRequeue, finalVictims...)
 	}
 	return reclaimedEnough, reclaimedGPU, finalPendingJobTopology, jobsToRequeue
+}
+
+func isQueueOverused(ssn *framework.Session, victimJob *api.JobInfo) bool {
+	queueAllocatedGPUs := ssn.Queues[victimJob.Queue].GetAllocatedGPU()
+	queueDeservedGPUs := ssn.Queues[victimJob.Queue].GetDeservedGPU()
+	return queueAllocatedGPUs > queueDeservedGPUs
 }
 
 func noBudgetViolationAfterReclaim(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) bool {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -23,8 +23,6 @@ limitations under the License.
 package reclaim
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -49,8 +47,8 @@ func (ra *Action) Execute(ssn *framework.Session) {
 	klog.V(5).Infof("Enter Reclaim ...")
 	defer klog.V(5).Infof("Leaving Reclaim ...")
 
-	pendingJobs := util.NewPriorityQueue(ssn.PreemptorJobOrderFn)
-	victimJobs := util.NewPriorityQueue(ssn.PreempteeJobOrderFn)
+	pendingJobs := util.NewPriorityQueue(preemptorJobOrder(ssn))
+	runningJobs := util.NewPriorityQueue(preempteeJobOrder(ssn))
 
 	for _, job := range ssn.Jobs {
 		// job.IsPending check if the job has passed the Enqueue phase.
@@ -62,7 +60,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		if job.IsStarving() {
 			pendingJobs.Push(job)
 		} else {
-			victimJobs.Push(job)
+			runningJobs.Push(job)
 		}
 	}
 
@@ -84,239 +82,32 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		reclaimedResource := api.EmptyResource()
-		reclaimedEnough := false
-		finalVictims := []*api.JobInfo{}
-		for {
-			if reclaimedEnough || victimJobs.Empty() {
-				break
-			}
-			victimJob := victimJobs.Pop().(*api.JobInfo)
-			finalVictims = append(finalVictims, victimJob)
-			reclaimedResource.Add(victimJob.TotalRequest)
-			if reclaimedResource.LessEqual(pendingJob.TotalRequest, api.Zero) {
-				reclaimedEnough = true
-				break
-			}
-		}
-
+		reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue := getReclaimedResources(ssn, pendingJob, runningJobs)
 		if !reclaimedEnough {
 			klog.V(3).Infof(`Job <%s/%s> Queue <%s> can not reclaim resources due to not enough resources. 
-			Reclaimed resources: <%v>, requested resources: <%v>`,
-				pendingJob.Namespace, pendingJob.Name, pendingJob.Queue, reclaimedResource, pendingJob.TotalRequest)
+			Reclaimed GPU: <%d>, requested resources: <%d>`,
+				pendingJob.Namespace, pendingJob.Name, pendingJob.Queue, reclaimedGPU, pendingJob.GetTotalRequestGPU())
 
-			// push back the victims that were not reclaimed
-			for _, victim := range finalVictims {
-				victimJobs.Push(victim)
+			// push back the jobs that would not be reclaimed
+			for _, victim := range jobsToRequeue {
+				runningJobs.Push(victim)
 			}
 			continue
 		}
 
-		for _, victim := range finalVictims {
-			errs := evictJob(ssn, victim, pendingJob.Name)
-			if len(errs) > 0 {
-				klog.Errorf("Failed to reclaim job <%s/%s> for job <%s/%s>: %v",
-					victim.Namespace, victim.Name, pendingJob.Namespace, pendingJob.Name, errs)
-				continue
+		for _, task := range pendingJobTopology {
+			err := ssn.Evict(task.Task, "reclaim for job "+pendingJob.Name)
+			if err != nil {
+				klog.Errorf("Failed to evict task <%s/%s> for job <%s/%s>: %v",
+					task.Task.Namespace, task.Task.Name, pendingJob.Namespace, pendingJob.Name, err)
 			}
-		}
-
-		// since killing one task in a job terminates the whole job, we try to pipeline the job here
-		if err := ssn.Pipeline(pendingJob, ""); err != nil {
-			klog.Errorf("Failed to pipeline job <%s/%s>: %v", pendingJob.Namespace, pendingJob.Name, err)
-			continue
+			// we still try to pipeline the task even if it fails to evict
+			// because it might be a victim of a gang job
+			if err := ssn.Pipeline(task.Task, task.NodeName); err != nil {
+				klog.Errorf("Failed to pipeline job <%s/%s>: %v", pendingJob.Namespace, pendingJob.Name, err)
+			}
 		}
 	}
-
-	// queues := util.NewPriorityQueue(ssn.QueueOrderFn)
-	// queueMap := map[api.QueueID]*api.QueueInfo{}
-
-	// preemptorsMap := map[api.QueueID]*util.PriorityQueue{}
-	// preemptorTasks := map[api.JobID]*util.PriorityQueue{}
-	// preempteesMap := map[api.QueueID]*util.PriorityQueue{}
-
-	// klog.V(3).Infof("There are <%d> Jobs and <%d> Queues in total for scheduling.",
-	// 	len(ssn.Jobs), len(ssn.Queues))
-
-	// for _, job := range ssn.Jobs {
-	// 	if job.IsPending() {
-	// 		continue
-	// 	}
-
-	// 	if vr := ssn.JobValid(job); vr != nil && !vr.Pass {
-	// 		klog.V(4).Infof("Job <%s/%s> Queue <%s> skip reclaim, reason: %v, message %v", job.Namespace, job.Name, job.Queue, vr.Reason, vr.Message)
-	// 		continue
-	// 	}
-	// 	queue, found := ssn.Queues[job.Queue]
-	// 	if !found {
-	// 		klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>", job.Queue, job.Namespace, job.Name)
-	// 		continue
-	// 	}
-	// 	if _, found := queueMap[queue.UID]; !found {
-	// 		klog.V(4).Infof("Added Queue <%s> for Job <%s/%s>", queue.Name, job.Namespace, job.Name)
-	// 		queueMap[queue.UID] = queue
-	// 		queues.Push(queue)
-	// 	}
-
-	// 	// if it's starving, it means the job is pending for more resources
-	// 	if ssn.JobStarving(job) {
-	// 		if _, found := preemptorsMap[job.Queue]; !found {
-	// 			preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
-	// 		}
-	// 		preemptorsMap[job.Queue].Push(job)
-	// 		preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
-	// 		for _, task := range job.TaskStatusIndex[api.Pending] {
-	// 			if task.SchGated {
-	// 				continue
-	// 			}
-	// 			preemptorTasks[job.UID].Push(task)
-	// 		}
-	// 	} else {
-	// 		if _, found := preempteesMap[job.Queue]; !found {
-	// 			preempteesMap[job.Queue] = util.NewPriorityQueue(VictimJobOrder)
-	// 		}
-	// 		preempteesMap[job.Queue].Push(job)
-	// 	}
-	// }
-
-	// for {
-	// 	// If no queues, break
-	// 	if queues.Empty() {
-	// 		break
-	// 	}
-
-	// 	var job *api.JobInfo
-	// 	var task *api.TaskInfo
-
-	// 	queue := queues.Pop().(*api.QueueInfo)
-	// 	if ssn.Overused(queue) {
-	// 		klog.V(3).Infof("Queue <%s> is overused <%v>, ignore it.", queue.Name, queue.Queue.Status.Allocated)
-	// 		continue
-	// 	}
-
-	// 	// Get all jobs based on the queue and the queue is selected based on the QueueOrderFn on L50
-	// 	jobs, found := preemptorsMap[queue.UID]
-	// 	if !found || jobs.Empty() {
-	// 		continue
-	// 	}
-	// 	// The job is selected based on the JobOrderFn on L80
-	// 	job = jobs.Pop().(*api.JobInfo)
-
-	// 	// TODO: job doesn't have the preemptionPolicy information, so we pop one task to check that for now
-	// 	tasks, found := preemptorTasks[job.UID]
-	// 	if !found || tasks.Empty() {
-	// 		queues.Push(queue)
-	// 		continue
-	// 	}
-	// 	task = tasks.Pop().(*api.TaskInfo)
-	// 	if task.Pod.Spec.PreemptionPolicy != nil && *task.Pod.Spec.PreemptionPolicy == v1.PreemptNever {
-	// 		klog.V(3).Infof("Task %s/%s is not eligible to preempt other tasks due to preemptionPolicy is Never", task.Namespace, task.Name)
-	// 		queues.Push(queue)
-	// 		continue
-	// 	}
-
-	// 	// Here we're mainly using the PreemptiveFn of the capacity plugin to check if the queue can reclaim
-	// 	if !ssn.Preemptive(queue, job) {
-	// 		klog.V(3).Infof("Queue <%s> can not reclaim by evicting others when considering job <%s> , ignore it.", queue.Name, job.Name)
-	// 		continue
-	// 	}
-
-	// 	// TODO: we should use PrePredicateFn to check all tasks in the job
-	// 	if err := ssn.PrePredicateFn(task); err != nil {
-	// 		klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
-	// 		continue
-	// 	}
-
-	// 	assigned := false
-	// 	// we should filter out those nodes that are UnschedulableAndUnresolvable status got in allocate action
-	// 	totalNodes := ssn.FilterOutUnschedulableAndUnresolvableNodesForTask(task)
-	// 	for _, n := range totalNodes {
-	// 		// When filtering candidate nodes, need to consider the node statusSets instead of the err information.
-	// 		// refer to kube-scheduler preemption code: https://github.com/kubernetes/kubernetes/blob/9d87fa215d9e8020abdc17132d1252536cd752d2/pkg/scheduler/framework/preemption/preemption.go#L422
-	// 		if err := ssn.PredicateForPreemptAction(task, n); err != nil {
-	// 			klog.V(4).Infof("Reclaim predicate for task %s/%s on node %s return error %v ", task.Namespace, task.Name, n.Name, err)
-	// 			continue
-	// 		}
-
-	// 		klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.", task.Namespace, task.Name, n.Name)
-
-	// 		var reclaimees []*api.TaskInfo
-	// 		for _, task := range n.Tasks {
-	// 			// Ignore non running task.
-	// 			if task.Status != api.Running {
-	// 				continue
-	// 			}
-	// 			if !task.Preemptable {
-	// 				continue
-	// 			}
-
-	// 			if j, found := ssn.Jobs[task.Job]; !found {
-	// 				continue
-	// 			} else if j.Queue != job.Queue {
-	// 				q := ssn.Queues[j.Queue]
-	// 				if !q.Reclaimable() {
-	// 					continue
-	// 				}
-	// 				// Clone task to avoid modify Task's status on node.
-	// 				reclaimees = append(reclaimees, task.Clone())
-	// 			}
-	// 		}
-
-	// 		if len(reclaimees) == 0 {
-	// 			klog.V(3).Infof("No reclaimees on Node <%s>.", n.Name)
-	// 			continue
-	// 		}
-
-	// 		victims := ssn.Reclaimable(task, reclaimees)
-
-	// 		if err := util.ValidateVictims(task, n, victims); err != nil {
-	// 			klog.V(3).Infof("No validated victims on Node <%s>: %v", n.Name, err)
-	// 			continue
-	// 		}
-
-	// 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
-
-	// 		resreq := task.InitResreq.Clone()
-	// 		reclaimed := n.FutureIdle()
-
-	// 		// Reclaim victims for tasks.
-	// 		for !victimsQueue.Empty() {
-	// 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
-	// 			klog.Errorf("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
-	// 				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
-	// 			if err := ssn.Evict(reclaimee, "reclaim for task "+task.Name); err != nil {
-	// 				klog.Errorf("Failed to reclaim Task <%s/%s> for Tasks <%s/%s>: %v",
-	// 					reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name, err)
-	// 				continue
-	// 			}
-	// 			reclaimed.Add(reclaimee.Resreq)
-	// 			// If reclaimed enough resources, break loop to avoid Sub panic.
-	// 			if resreq.LessEqual(reclaimed, api.Zero) {
-	// 				break
-	// 			}
-	// 		}
-
-	// 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>.",
-	// 			reclaimed, task.Namespace, task.Name, task.InitResreq)
-
-	// 		if task.InitResreq.LessEqual(reclaimed, api.Zero) {
-	// 			if err := ssn.Pipeline(task, n.Name); err != nil {
-	// 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
-	// 					task.Namespace, task.Name, n.Name)
-	// 			}
-
-	// 			// Ignore error of pipeline, will be corrected in next scheduling loop.
-	// 			assigned = true
-
-	// 			break
-	// 		}
-	// 	}
-
-	// 	if assigned {
-	// 		jobs.Push(job)
-	// 	}
-	// 	queues.Push(queue)
-	// }
 }
 
 func (ra *Action) UnInitialize() {
@@ -332,25 +123,210 @@ func jobPolicyAllowPeemption(job *api.JobInfo) bool {
 	return true
 }
 
-// TODO: check if we need to evict all tasks or not because
-// we have TerminateJob
-func evictJob(ssn *framework.Session, victimJob *api.JobInfo, pendingJobName string) []error {
-	numberOfTasksToEvict := len(victimJob.Tasks) - int(victimJob.TaskMinAvailableTotal)
-	if numberOfTasksToEvict <= 0 {
-		numberOfTasksToEvict = len(victimJob.Tasks)
-	}
-	i := 0
-	errors := []error{}
-	// TODO: we should iterate tasks based on node to have better bin packing
-	for _, task := range victimJob.Tasks {
-		err := ssn.Evict(task, "reclaim for job "+pendingJobName)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("failed to evict task <%s/%s>: %v", task.Namespace, task.Name, err))
+type VictimTask struct {
+	NodeName string
+	GPU      int64
+	Task     *api.TaskInfo
+}
+
+func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runningJobs *util.PriorityQueue) (bool, int64, map[string]*VictimTask, []*api.JobInfo) {
+	reclaimedGPU := int64(0)
+	reclaimedEnough := false
+	finalVictims := []*api.JobInfo{}
+	skippedVictims := []*api.JobInfo{}
+	pendingJobTopology := map[string]*VictimTask{}
+	for {
+		if reclaimedEnough || runningJobs.Empty() {
+			break
 		}
-		i++
-		if i >= numberOfTasksToEvict {
+		jobToEvict := runningJobs.Pop().(*api.JobInfo)
+		// first we check if it violates the budget when the victimJob is reclaimed
+		if !noBudgetViolationAfterReclaim(ssn, jobToEvict, pendingJob) {
+			skippedVictims = append(skippedVictims, jobToEvict)
+			continue
+		}
+		// then we need to check if the node can accommodate the task
+		pendingJobTopology = findNodesForPendingJob(ssn, jobToEvict, pendingJob)
+		if len(pendingJobTopology) == 0 {
+			skippedVictims = append(skippedVictims, jobToEvict)
+			continue
+		}
+
+		finalVictims = append(finalVictims, jobToEvict)
+		for _, n := range pendingJobTopology {
+			reclaimedGPU += n.GPU
+		}
+		if reclaimedGPU >= pendingJob.GetTotalRequestGPU() {
+			reclaimedEnough = true
 			break
 		}
 	}
-	return errors
+	// we need to requeue the skipped jobs because they might be victims of other jobs
+	jobsToRequeue := skippedVictims
+	if !reclaimedEnough {
+		// we need to include the final victims because we didn't reclaim enough so they won't be evicted
+		jobsToRequeue = append(jobsToRequeue, finalVictims...)
+	}
+	return reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue
+}
+
+func noBudgetViolationAfterReclaim(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) bool {
+	queueAllocatedGPUs := ssn.Queues[victimJob.Queue].GetAllocatedGPU()
+	queueDeservedGPUs := ssn.Queues[victimJob.Queue].GetDeservedGPU()
+
+	withoutVictimJob := int64(0)
+	if len(victimJob.Tasks) == int(victimJob.TaskMinAvailableTotal) {
+		// when it's not an elastic workload, we check the total request of the job
+		withoutVictimJob = queueAllocatedGPUs - victimJob.GetTotalRequestGPU()
+	} else {
+		// when it's an elastic workload, we check the minimum between the elastic GPUs and the requested GPUs of the victim job
+		elasticGPUs := victimJob.GetElasticGPUs()
+		requestedGPUs := pendingJob.GetTotalRequestGPU()
+		withoutVictimJob = queueAllocatedGPUs - min(elasticGPUs, requestedGPUs)
+	}
+	if queueDeservedGPUs <= withoutVictimJob {
+		return true
+	}
+	return false
+}
+
+func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) map[string]*VictimTask {
+	// topology maps have "required number of GPUs" -> "node names"
+	// {1: ["node1", "node2"]} means the nodes
+	// using the VictimTask struct instead of a single node name string because we need to carry the task information
+	// and the idle gpu count on that node for the calculation below
+	victimTopology := map[int64][]*VictimTask{}
+	for _, task := range victimJob.Tasks {
+		node := ssn.Nodes[task.NodeName]
+		if node == nil {
+			continue
+		}
+		// we need to consider future idle in case the node wasn't fully occupied by the victim task
+		nodeFutureIdleGPU := node.FutureIdle().ScalarResources["nvidia.com/gpu"]
+		numGPU := int64(task.Resreq.ScalarResources["nvidia.com/gpu"] + nodeFutureIdleGPU)
+		victimTopology[numGPU] = append(victimTopology[numGPU], &VictimTask{
+			NodeName: task.NodeName,
+			GPU:      numGPU,
+			Task:     task,
+		})
+	}
+	// record task name -> node name so we know how to pipeline the tasks later
+	pendingJobTopology := map[string]*VictimTask{}
+	for _, task := range pendingJob.Tasks {
+		requiredGPU := int64(task.Resreq.ScalarResources["nvidia.com/gpu"])
+		taskAssigned := false
+		for i := requiredGPU; i <= 8; i++ {
+			nodes, ok := victimTopology[i]
+			if !ok || len(nodes) == 0 {
+				continue
+			}
+			for idx, node := range nodes {
+				if node.GPU < requiredGPU {
+					continue
+				}
+				node.GPU -= requiredGPU
+				if node.GPU == 0 {
+					// remove the node
+					victimTopology[i] = deleteFromSlice(victimTopology[i], idx)
+				}
+				pendingJobTopology[task.Name] = node
+				taskAssigned = true
+				break
+			}
+			if taskAssigned {
+				break
+			}
+		}
+	}
+	return pendingJobTopology
+}
+
+func deleteFromSlice(slice []*VictimTask, index int) []*VictimTask {
+	if index < 0 || index >= len(slice) {
+		return slice
+	}
+	if index == 0 {
+		return slice[1:]
+	}
+	if index == len(slice)-1 {
+		return slice[:index]
+	}
+	return append(slice[:index], slice[index+1:]...)
+}
+
+func preempteeJobOrder(ssn *framework.Session) func(l, r interface{}) bool {
+	return func(l, r interface{}) bool {
+		lJob := l.(*api.JobInfo)
+		rJob := r.(*api.JobInfo)
+
+		lvElasticResources := lJob.GetElasticGPUs()
+		rvElasticResources := rJob.GetElasticGPUs()
+
+		if lvElasticResources != rvElasticResources {
+			// this will be used as a LessThan function in building up the heap,
+			// so we need to return the opposite of the comparison to prioritize the job with more elastic replicas
+			return lvElasticResources > rvElasticResources
+		}
+
+		// when jobs have the same elastic replicas, we compare the queue priorities
+		lQueue := ssn.Queues[lJob.Queue]
+		rQueue := ssn.Queues[rJob.Queue]
+
+		if lQueue.Queue.Spec.Priority != rQueue.Queue.Spec.Priority {
+			return lQueue.Queue.Spec.Priority < rQueue.Queue.Spec.Priority
+		}
+
+		// when jobs have the same elastic replicas and queue priorities, we compare the queue overusage
+		lvOverusage := getQueueOverusage(lQueue)
+		rvOverusage := getQueueOverusage(rQueue)
+		if lvOverusage != rvOverusage {
+			// we want to prioritize the queue with more overusage
+			return lvOverusage > rvOverusage
+		}
+
+		// we compare the priorities of the jobs
+		if lJob.Priority != rJob.Priority {
+			return lJob.Priority < rJob.Priority
+		}
+
+		// compare the number of tasks in a job, and we prioritize the job with fewer tasks
+		lTasks := len(lJob.Tasks)
+		rTasks := len(rJob.Tasks)
+		if lTasks != rTasks {
+			return lTasks < rTasks
+		}
+
+		// lastly we compare the job creation timestamp
+		return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
+	}
+}
+
+func getQueueOverusage(queue *api.QueueInfo) float64 {
+	allocatedGPUs := queue.GetAllocatedGPU()
+	deservedGPUs := queue.GetDeservedGPU()
+	overusage := float64(allocatedGPUs-deservedGPUs) / float64(deservedGPUs)
+	if overusage < 0 {
+		return 0
+	}
+	return overusage
+}
+
+func preemptorJobOrder(ssn *framework.Session) func(l, r interface{}) bool {
+	return func(l, r interface{}) bool {
+		lJob := l.(*api.JobInfo)
+		rJob := r.(*api.JobInfo)
+
+		lQueue := ssn.Queues[lJob.Queue]
+		rQueue := ssn.Queues[rJob.Queue]
+
+		if lQueue.Queue.Spec.Priority != rQueue.Queue.Spec.Priority {
+			return lQueue.Queue.Spec.Priority > rQueue.Queue.Spec.Priority
+		}
+
+		if lJob.Priority != rJob.Priority {
+			return lJob.Priority > rJob.Priority
+		}
+
+		return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
+	}
 }

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -82,11 +82,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue := getReclaimedResources(ssn, pendingJob.Clone(), runningJobs)
-		// push back the jobs that would not be reclaimed
-		for _, victim := range jobsToRequeue {
-			runningJobs.Push(victim)
-		}
+		reclaimedEnough, reclaimedGPU, pendingJobTopology := getReclaimedResources(ssn, pendingJob.Clone(), runningJobs.Clone())
 		if !reclaimedEnough {
 			klog.V(3).Infof(`Job <%s/%s> can not reclaim resources due to not enough resources. Reclaimed GPU: <%d>, requested GPUs: <%d>`,
 				pendingJob.Queue, pendingJob.Name, reclaimedGPU, pendingJob.GetTotalRequestGPU())
@@ -124,11 +120,9 @@ func jobPolicyAllowPeemption(job *api.JobInfo) bool {
 	return true
 }
 
-func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runningJobs *util.PriorityQueue) (bool, int64, map[string]*EvictTask, []*api.JobInfo) {
+func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runningJobs *util.PriorityQueue) (bool, int64, map[string]*EvictTask) {
 	reclaimedGPU := int64(0)
 	reclaimedEnough := false
-	finalVictims := []*api.JobInfo{}
-	skippedVictims := []*api.JobInfo{}
 	finalPendingJobTopology := map[string]*EvictTask{}
 	for {
 		if reclaimedEnough || runningJobs.Empty() {
@@ -136,22 +130,21 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		}
 		jobToEvict := runningJobs.Pop().(*api.JobInfo)
 		if jobToEvict.Queue == pendingJob.Queue {
-			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
 		klog.V(3).Infof("Checking if job <%s/%s> can be evicted", jobToEvict.Queue, jobToEvict.Name)
 		// first we check if the queue is overused
 		if !isQueueOverused(ssn, jobToEvict) {
 			klog.V(3).Infof("Job <%s/%s> can not be evicted because the queue is not overused", jobToEvict.Queue, jobToEvict.Name)
-			skippedVictims = append(skippedVictims, jobToEvict)
 			continue
 		}
 		// then we need to check if the node can accommodate the task
 		pendingJobTopology := findNodesForPendingJob(ssn, jobToEvict, pendingJob)
 		if len(pendingJobTopology) == 0 {
-			skippedVictims = append(skippedVictims, jobToEvict)
+			klog.V(3).Infof("Job <%s/%s> can not be evicted because the node can not accommodate the task", jobToEvict.Queue, jobToEvict.Name)
 			continue
 		}
+		klog.V(3).Infof("found nodes to accommodate %d tasks for job <%s/%s>", len(pendingJobTopology), pendingJob.Queue, pendingJob.Name)
 
 		for _, n := range pendingJobTopology {
 			finalPendingJobTopology[n.PendingTask.Name] = n
@@ -159,19 +152,13 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 			reclaimedGPU += n.GPU
 		}
 
-		finalVictims = append(finalVictims, jobToEvict)
 		if reclaimedGPU >= pendingJob.GetTotalRequestGPU() {
+			klog.V(3).Infof("found enough resources to reclaim for job <%s/%s>", pendingJob.Queue, pendingJob.Name)
 			reclaimedEnough = true
 			break
 		}
 	}
-	// we need to requeue the skipped jobs because they might be victims of other jobs
-	jobsToRequeue := skippedVictims
-	if !reclaimedEnough {
-		// we need to include the final victims because we didn't reclaim enough so they won't be evicted
-		jobsToRequeue = append(jobsToRequeue, finalVictims...)
-	}
-	return reclaimedEnough, reclaimedGPU, finalPendingJobTopology, jobsToRequeue
+	return reclaimedEnough, reclaimedGPU, finalPendingJobTopology
 }
 
 func isQueueOverused(ssn *framework.Session, victimJob *api.JobInfo) bool {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -155,6 +155,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 
 		for _, n := range pendingJobTopology {
 			finalPendingJobTopology[n.PendingTask.Name] = n
+			// Count total reclaimed capacity (idle + evicted) allocated to this pending task
 			reclaimedGPU += n.GPU
 		}
 
@@ -179,26 +180,6 @@ func isQueueOverused(ssn *framework.Session, victimJob *api.JobInfo) bool {
 	return queueAllocatedGPUs > queueDeservedGPUs
 }
 
-func noBudgetViolationAfterReclaim(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) bool {
-	queueAllocatedGPUs := ssn.Queues[victimJob.Queue].GetAllocatedGPU()
-	queueDeservedGPUs := ssn.Queues[victimJob.Queue].GetDeservedGPU()
-
-	withoutVictimJob := int64(0)
-	if len(victimJob.Tasks) == int(victimJob.MinAvailable) {
-		// when it's not an elastic workload, we check the total request of the job
-		withoutVictimJob = queueAllocatedGPUs - victimJob.GetTotalRequestGPU()
-	} else {
-		// when it's an elastic workload, we check the minimum between the elastic GPUs and the requested GPUs of the victim job
-		elasticGPUs := victimJob.GetElasticGPUs()
-		requestedGPUs := pendingJob.GetTotalRequestGPU()
-		withoutVictimJob = queueAllocatedGPUs - min(elasticGPUs, requestedGPUs)
-	}
-	if queueDeservedGPUs <= withoutVictimJob {
-		return true
-	}
-	return false
-}
-
 type EvictTask struct {
 	NodeName     string
 	GPU          int64
@@ -207,67 +188,106 @@ type EvictTask struct {
 }
 
 func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) map[string]*EvictTask {
-	// topology maps have "required number of GPUs" -> "node names"
-	// {1: ["node1", "node2"]} means the nodes
-	// using the VictimTask struct instead of a single node name string because we need to carry the task information
-	// and the idle gpu count on that node for the calculation below
-	victimNodes := map[string]*EvictTask{}
-	for _, task := range victimJob.Tasks {
-		node := ssn.Nodes[task.NodeName]
+	// Build per-node capacity with idle counted once and evictable tasks listed
+	type nodeCapacity struct {
+		nodeName     string
+		idleGPU      int64
+		evictable    []*api.TaskInfo
+		evictableGPU int64
+	}
+
+	nodeCaps := map[string]*nodeCapacity{}
+	for _, t := range victimJob.Tasks {
+		node := ssn.Nodes[t.NodeName]
 		if node == nil {
 			continue
 		}
-		// we need to consider future idle in case the node wasn't fully occupied by the victim task
-		nodeFutureIdleGPU := node.FutureIdle().ScalarResources["nvidia.com/gpu"]
-		numGPU := int64(task.Resreq.ScalarResources["nvidia.com/gpu"] + nodeFutureIdleGPU)
-		tasks, ok := victimNodes[task.NodeName]
+		gpu := int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
+		cap, ok := nodeCaps[t.NodeName]
 		if !ok {
-			victimNodes[task.NodeName] = &EvictTask{
-				NodeName:     task.NodeName,
-				GPU:          numGPU,
-				TasksToEvict: []*api.TaskInfo{task},
+			cap = &nodeCapacity{
+				nodeName:     t.NodeName,
+				idleGPU:      int64(node.FutureIdle().ScalarResources["nvidia.com/gpu"]),
+				evictable:    []*api.TaskInfo{},
+				evictableGPU: 0,
 			}
-		} else {
-			victimNodes[task.NodeName] = &EvictTask{
-				NodeName:     task.NodeName,
-				GPU:          tasks.GPU + numGPU,
-				TasksToEvict: append(tasks.TasksToEvict, task),
-			}
+			nodeCaps[t.NodeName] = cap
 		}
+		cap.evictable = append(cap.evictable, t)
+		cap.evictableGPU += gpu
 	}
+
 	// record task name -> node name so we know how to pipeline the tasks later
 	pendingJobTopology := map[string]*EvictTask{}
 	for _, task := range pendingJob.Tasks {
-		requiredGPU := int64(task.Resreq.ScalarResources["nvidia.com/gpu"])
-		for _, node := range victimNodes {
-			if node.GPU < requiredGPU {
+		required := int64(task.Resreq.ScalarResources["nvidia.com/gpu"])
+		placed := false
+		for _, cap := range nodeCaps {
+			totalAvail := cap.idleGPU + cap.evictableGPU
+			if totalAvail < required {
 				continue
 			}
+
+			// simulate consumption on this node
+			remainingIdle := cap.idleGPU
+			remainingTasks := make([]*api.TaskInfo, len(cap.evictable))
+			copy(remainingTasks, cap.evictable)
+
 			result := &EvictTask{
-				NodeName:    node.NodeName,
+				NodeName:    cap.nodeName,
 				PendingTask: task,
-				GPU:         int64(0),
+				GPU:         0,
 			}
-			if len(node.TasksToEvict) == 0 {
-				node.GPU -= requiredGPU
-				result.GPU = requiredGPU
-				pendingJobTopology[task.Name] = result
-				delete(pendingJob.Tasks, task.UID)
-				break
-			}
-			for idx, t := range node.TasksToEvict {
-				requiredGPU -= int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
-				result.TasksToEvict = append(result.TasksToEvict, t)
-				result.GPU += int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
-				node.GPU -= int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
-				node.TasksToEvict = deleteFromSlice(node.TasksToEvict, idx)
-				if requiredGPU == 0 {
-					break
+
+			// use idle first
+			if remainingIdle > 0 {
+				use := remainingIdle
+				if use > required {
+					use = required
 				}
+				remainingIdle -= use
+				required -= use
+				result.GPU += use
 			}
+
+			// then evict tasks until satisfied
+			evictedIdx := 0
+			for required > 0 && evictedIdx < len(remainingTasks) {
+				vt := remainingTasks[evictedIdx]
+				g := int64(vt.Resreq.ScalarResources["nvidia.com/gpu"])
+				result.TasksToEvict = append(result.TasksToEvict, vt)
+				result.GPU += g
+				required -= g
+				evictedIdx++
+			}
+
+			if required > 0 {
+				// not enough even after evictions; try another node
+				continue
+			}
+
+			// commit consumption to this node capacity
+			cap.idleGPU = remainingIdle
+			if evictedIdx >= len(remainingTasks) {
+				cap.evictable = []*api.TaskInfo{}
+			} else {
+				cap.evictable = remainingTasks[evictedIdx:]
+			}
+			// recompute evictableGPU after removing evicted tasks
+			newEvictableGPU := int64(0)
+			for _, vt := range cap.evictable {
+				newEvictableGPU += int64(vt.Resreq.ScalarResources["nvidia.com/gpu"])
+			}
+			cap.evictableGPU = newEvictableGPU
+
 			pendingJobTopology[task.Name] = result
 			delete(pendingJob.Tasks, task.UID)
+			placed = true
 			break
+		}
+		if !placed {
+			// could not place this pending task with this victim job's nodes
+			continue
 		}
 	}
 	return pendingJobTopology

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -70,6 +70,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		}
 
 		pendingJob := pendingJobs.Pop().(*api.JobInfo)
+		klog.V(3).Infof("Reclaiming resources for job <%s/%s>", pendingJob.Queue, pendingJob.Name)
 		// it uses the PreemptiveFn of the capacity plugin to check if the queue can reclaim.
 		// A queue can not reclaim when allocated + job.TotalRequest > deserved.
 		if !ssn.Preemptive(ssn.Queues[pendingJob.Queue], pendingJob) {
@@ -132,7 +133,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		if jobToEvict.Queue == pendingJob.Queue {
 			continue
 		}
-		klog.V(3).Infof("Checking if job <%s/%s> can be evicted", jobToEvict.Queue, jobToEvict.Name)
+		klog.V(3).Infof("JobToEvict: <%s/%s>", jobToEvict.Queue, jobToEvict.Name)
 		// first we check if the queue is overused
 		if !isQueueOverused(ssn, jobToEvict) {
 			klog.V(3).Infof("Job <%s/%s> can not be evicted because the queue is not overused", jobToEvict.Queue, jobToEvict.Name)
@@ -144,7 +145,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 			klog.V(3).Infof("Job <%s/%s> can not be evicted because the node can not accommodate the task", jobToEvict.Queue, jobToEvict.Name)
 			continue
 		}
-		klog.V(3).Infof("found nodes to accommodate %d tasks for job <%s/%s>", len(pendingJobTopology), pendingJob.Queue, pendingJob.Name)
+		klog.V(3).Infof("Job %s/%s will evict tasks: %v", pendingJob.Queue, pendingJob.Name, pendingJobTopology)
 
 		for _, n := range pendingJobTopology {
 			finalPendingJobTopology[n.PendingTask.Name] = n
@@ -153,7 +154,7 @@ func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runn
 		}
 
 		if reclaimedGPU >= pendingJob.GetTotalRequestGPU() {
-			klog.V(3).Infof("found enough resources to reclaim for job <%s/%s>", pendingJob.Queue, pendingJob.Name)
+			klog.V(3).Infof("Job <%s/%s> will reclaim enough resources", pendingJob.Queue, pendingJob.Name)
 			reclaimedEnough = true
 			break
 		}
@@ -278,19 +279,6 @@ func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.J
 		}
 	}
 	return pendingJobTopology
-}
-
-func deleteFromSlice[T any](slice []T, index int) []T {
-	if index < 0 || index >= len(slice) {
-		return slice
-	}
-	if index == 0 {
-		return slice[1:]
-	}
-	if index == len(slice)-1 {
-		return slice[:index]
-	}
-	return append(slice[:index], slice[index+1:]...)
 }
 
 func preempteeJobOrder(ssn *framework.Session) func(l, r interface{}) bool {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -238,6 +238,11 @@ func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.J
 			result := &EvictTask{
 				NodeName:    node.NodeName,
 				PendingTask: task,
+				GPU:         requiredGPU,
+			}
+			if len(node.TasksToEvict) == 0 {
+				node.GPU -= requiredGPU
+				break
 			}
 			for idx, t := range node.TasksToEvict {
 				requiredGPU -= int64(t.Resreq.ScalarResources["nvidia.com/gpu"])

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -84,8 +84,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 
 		reclaimedEnough, reclaimedGPU, pendingJobTopology, jobsToRequeue := getReclaimedResources(ssn, pendingJob, runningJobs)
 		if !reclaimedEnough {
-			klog.V(3).Infof(`Job <%s/%s> Queue <%s> can not reclaim resources due to not enough resources. 
-			Reclaimed GPU: <%d>, requested resources: <%d>`,
+			klog.V(3).Infof(`Job <%s/%s> Queue <%s> can not reclaim resources due to not enough resources. Reclaimed GPU: <%d>, requested GPUs: <%d>`,
 				pendingJob.Namespace, pendingJob.Name, pendingJob.Queue, reclaimedGPU, pendingJob.GetTotalRequestGPU())
 
 			// push back the jobs that would not be reclaimed
@@ -96,14 +95,16 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		}
 
 		for _, task := range pendingJobTopology {
-			err := ssn.Evict(task.Task, "reclaim for job "+pendingJob.Name)
-			if err != nil {
-				klog.Errorf("Failed to evict task <%s/%s> for job <%s/%s>: %v",
-					task.Task.Namespace, task.Task.Name, pendingJob.Namespace, pendingJob.Name, err)
+			for _, t := range task.TasksToEvict {
+				err := ssn.Evict(t, "reclaim for job "+pendingJob.Name)
+				if err != nil {
+					klog.Errorf("Failed to evict task <%s/%s> for job <%s/%s>: %v",
+						t.Namespace, t.Name, pendingJob.Namespace, pendingJob.Name, err)
+				}
 			}
 			// we still try to pipeline the task even if it fails to evict
 			// because it might be a victim of a gang job
-			if err := ssn.Pipeline(task.Task, task.NodeName); err != nil {
+			if err := ssn.Pipeline(task.PendingTask, task.NodeName); err != nil {
 				klog.Errorf("Failed to pipeline job <%s/%s>: %v", pendingJob.Namespace, pendingJob.Name, err)
 			}
 		}
@@ -123,23 +124,21 @@ func jobPolicyAllowPeemption(job *api.JobInfo) bool {
 	return true
 }
 
-type VictimTask struct {
-	NodeName string
-	GPU      int64
-	Task     *api.TaskInfo
-}
-
-func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runningJobs *util.PriorityQueue) (bool, int64, map[string]*VictimTask, []*api.JobInfo) {
+func getReclaimedResources(ssn *framework.Session, pendingJob *api.JobInfo, runningJobs *util.PriorityQueue) (bool, int64, map[string]*EvictTask, []*api.JobInfo) {
 	reclaimedGPU := int64(0)
 	reclaimedEnough := false
 	finalVictims := []*api.JobInfo{}
 	skippedVictims := []*api.JobInfo{}
-	pendingJobTopology := map[string]*VictimTask{}
+	pendingJobTopology := map[string]*EvictTask{}
 	for {
 		if reclaimedEnough || runningJobs.Empty() {
 			break
 		}
 		jobToEvict := runningJobs.Pop().(*api.JobInfo)
+		if jobToEvict.Queue == pendingJob.Queue {
+			skippedVictims = append(skippedVictims, jobToEvict)
+			continue
+		}
 		// first we check if it violates the budget when the victimJob is reclaimed
 		if !noBudgetViolationAfterReclaim(ssn, jobToEvict, pendingJob) {
 			skippedVictims = append(skippedVictims, jobToEvict)
@@ -190,12 +189,19 @@ func noBudgetViolationAfterReclaim(ssn *framework.Session, victimJob, pendingJob
 	return false
 }
 
-func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) map[string]*VictimTask {
+type EvictTask struct {
+	NodeName     string
+	GPU          int64
+	TasksToEvict []*api.TaskInfo
+	PendingTask  *api.TaskInfo
+}
+
+func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.JobInfo) map[string]*EvictTask {
 	// topology maps have "required number of GPUs" -> "node names"
 	// {1: ["node1", "node2"]} means the nodes
 	// using the VictimTask struct instead of a single node name string because we need to carry the task information
 	// and the idle gpu count on that node for the calculation below
-	victimTopology := map[int64][]*VictimTask{}
+	victimNodes := map[string]*EvictTask{}
 	for _, task := range victimJob.Tasks {
 		node := ssn.Nodes[task.NodeName]
 		if node == nil {
@@ -204,44 +210,51 @@ func findNodesForPendingJob(ssn *framework.Session, victimJob, pendingJob *api.J
 		// we need to consider future idle in case the node wasn't fully occupied by the victim task
 		nodeFutureIdleGPU := node.FutureIdle().ScalarResources["nvidia.com/gpu"]
 		numGPU := int64(task.Resreq.ScalarResources["nvidia.com/gpu"] + nodeFutureIdleGPU)
-		victimTopology[numGPU] = append(victimTopology[numGPU], &VictimTask{
-			NodeName: task.NodeName,
-			GPU:      numGPU,
-			Task:     task,
-		})
+		tasks, ok := victimNodes[task.NodeName]
+		if !ok {
+			victimNodes[task.NodeName] = &EvictTask{
+				NodeName:     task.NodeName,
+				GPU:          numGPU,
+				TasksToEvict: []*api.TaskInfo{task},
+			}
+		} else {
+			victimNodes[task.NodeName] = &EvictTask{
+				NodeName:     task.NodeName,
+				GPU:          tasks.GPU + numGPU,
+				TasksToEvict: append(tasks.TasksToEvict, task),
+			}
+		}
 	}
 	// record task name -> node name so we know how to pipeline the tasks later
-	pendingJobTopology := map[string]*VictimTask{}
+	pendingJobTopology := map[string]*EvictTask{}
 	for _, task := range pendingJob.Tasks {
 		requiredGPU := int64(task.Resreq.ScalarResources["nvidia.com/gpu"])
-		taskAssigned := false
-		for i := requiredGPU; i <= 8; i++ {
-			nodes, ok := victimTopology[i]
-			if !ok || len(nodes) == 0 {
+		for _, node := range victimNodes {
+			if node.GPU < requiredGPU {
 				continue
 			}
-			for idx, node := range nodes {
-				if node.GPU < requiredGPU {
-					continue
-				}
-				node.GPU -= requiredGPU
-				if node.GPU == 0 {
-					// remove the node
-					victimTopology[i] = deleteFromSlice(victimTopology[i], idx)
-				}
-				pendingJobTopology[task.Name] = node
-				taskAssigned = true
-				break
+			result := &EvictTask{
+				NodeName:    node.NodeName,
+				PendingTask: task,
 			}
-			if taskAssigned {
-				break
+			for idx, t := range node.TasksToEvict {
+				requiredGPU -= int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
+				result.TasksToEvict = append(result.TasksToEvict, t)
+				result.GPU += int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
+				node.GPU -= int64(t.Resreq.ScalarResources["nvidia.com/gpu"])
+				node.TasksToEvict = deleteFromSlice(node.TasksToEvict, idx)
+				if requiredGPU == 0 {
+					break
+				}
 			}
+			pendingJobTopology[task.Name] = result
+			break
 		}
 	}
 	return pendingJobTopology
 }
 
-func deleteFromSlice(slice []*VictimTask, index int) []*VictimTask {
+func deleteFromSlice[T any](slice []T, index int) []T {
 	if index < 0 || index >= len(slice) {
 		return slice
 	}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -93,18 +93,18 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		for _, task := range pendingJobTopology {
+		for pendingTaskName, task := range pendingJobTopology {
 			for _, t := range task.TasksToEvict {
-				err := ssn.Evict(t, "reclaim for job "+string(pendingJob.Queue)+"/"+pendingJob.Name)
+				err := ssn.Evict(t, fmt.Sprintf("reclaim for task <%s/%s>", string(pendingJob.Queue), pendingTaskName))
 				if err != nil {
-					klog.Errorf("Failed to evict task <%s/%s> for job <%s/%s>: %v",
-						t.Namespace, t.Name, pendingJob.Namespace, pendingJob.Name, err)
+					klog.Errorf("Failed to evict task <%s/%s> for task <%s/%s>: %v",
+						t.Namespace, t.Name, pendingJob.Namespace, pendingTaskName, err)
 				}
 			}
 			// we still try to pipeline the task even if it fails to evict
 			// because it might be a victim of a gang job
 			if err := ssn.Pipeline(task.PendingTask, task.NodeName); err != nil {
-				klog.Errorf("Failed to pipeline job <%s/%s>: %v", pendingJob.Namespace, pendingJob.Name, err)
+				klog.Errorf("Failed to pipeline task <%s/%s>: %v", pendingJob.Namespace, pendingTaskName, err)
 			}
 		}
 	}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -1,4 +1,4 @@
-*
+/*
 Copyright 2018 The Kubernetes Authors.
 Copyright 2018-2025 The Volcano Authors.
 

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1089,8 +1089,8 @@ func (j *JobInfo) GetAllocatedGPU() int64 {
 }
 
 func (j *JobInfo) GetElasticGPUs() int64 {
-	elasticReplicas := len(j.Tasks) - int(j.TaskMinAvailableTotal)
-	if elasticReplicas < 0 {
+	elasticReplicas := len(j.Tasks) - int(j.MinAvailable)
+	if elasticReplicas <= 0 {
 		return 0
 	}
 	gpuPerTask := int64(0)

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1079,3 +1079,24 @@ func (ji *JobInfo) ResetFitErr() {
 	ji.JobFitErrors = ""
 	ji.NodesFitErrors = make(map[TaskID]*FitErrors)
 }
+
+func (j *JobInfo) GetTotalRequestGPU() int64 {
+	return int64(j.TotalRequest.Get("nvidia.com/gpu"))
+}
+
+func (j *JobInfo) GetAllocatedGPU() int64 {
+	return int64(j.Allocated.Get("nvidia.com/gpu"))
+}
+
+func (j *JobInfo) GetElasticGPUs() int64 {
+	elasticReplicas := len(j.Tasks) - int(j.TaskMinAvailableTotal)
+	if elasticReplicas < 0 {
+		return 0
+	}
+	gpuPerTask := int64(0)
+	for _, v := range j.Tasks {
+		gpuPerTask = int64(v.InitResreq.ScalarResources["nvidia.com/gpu"])
+		break
+	}
+	return int64(elasticReplicas) * gpuPerTask
+}

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -463,7 +463,7 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 
 	task, found := ni.Tasks[key]
 	if !found {
-		klog.Warningf("failed to find task <%v/%v> on host <%v>",
+		klog.V(4).Infof("failed to find task <%v/%v> on host <%v>",
 			ti.Namespace, ti.Name, ni.Name)
 		return nil
 	}

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -92,3 +92,13 @@ func (q *QueueInfo) Reclaimable() bool {
 
 	return *q.Queue.Spec.Reclaimable
 }
+
+func (q *QueueInfo) GetAllocatedGPU() int64 {
+	quantity := q.Queue.Status.Allocated["nvidia.com/gpu"]
+	return quantity.MilliValue()
+}
+
+func (q *QueueInfo) GetDeservedGPU() int64 {
+	quantity := q.Queue.Spec.Deserved["nvidia.com/gpu"]
+	return quantity.MilliValue()
+}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -802,3 +802,7 @@ func ExceededPart(left, right *Resource) *Resource {
 	diff, _ := left.Diff(right, Zero)
 	return diff
 }
+
+func IgnoreScalarResource(name v1.ResourceName) bool {
+	return name == "attachable-volumes-csi-fsx.csi.aws.com" || name == "efa.poolsi.de/infiniband" || name == "vpc.amazonaws.com/efa" || ignoredScalarResources.Has(string(name))
+}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -461,7 +461,7 @@ func (r *Resource) LessEqualWithDimension(rr *Resource, req *Resource) bool {
 	}
 
 	for name, quant := range req.ScalarResources {
-		if IsIgnoredScalarResource(name) {
+		if IgnoreScalarResource(name) {
 			continue
 		}
 		rQuant := r.ScalarResources[name]

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -494,6 +494,9 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
+		if IgnoreScalarResource(resourceName) {
+			continue
+		}
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
 			continue
@@ -530,6 +533,9 @@ func (r *Resource) LessPartly(rr *Resource, defaultValue DimensionDefaultValue) 
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
+		if IgnoreScalarResource(resourceName) {
+			continue
+		}
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
 			return true
@@ -566,6 +572,9 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
+		if IgnoreScalarResource(resourceName) {
+			continue
+		}
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
 			return true
@@ -591,6 +600,9 @@ func (r *Resource) Equal(rr *Resource, defaultValue DimensionDefaultValue) bool 
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
+		if IgnoreScalarResource(resourceName) {
+			continue
+		}
 		rightValue := rr.ScalarResources[resourceName]
 		if !equalFunc(leftValue, rightValue, minResource) {
 			return false

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -906,9 +906,9 @@ func (sc *SchedulerCache) Bind(ctx context.Context, bindContexts []*BindContext)
 	tmp := time.Now()
 	errMsg := sc.Binder.Bind(sc.kubeClient, readyToBindTasks)
 	if len(errMsg) == 0 {
-		klog.V(3).Infof("bind ok, latency %v", time.Since(tmp))
+		klog.V(4).Infof("bind ok, latency %v", time.Since(tmp))
 	} else {
-		klog.V(3).Infof("There are %d tasks in total and %d binds failed, latency %v", len(readyToBindTasks), len(errMsg), time.Since(tmp))
+		klog.V(4).Infof("There are %d tasks in total and %d binds failed, latency %v", len(readyToBindTasks), len(errMsg), time.Since(tmp))
 	}
 
 	for _, bindContext := range bindContexts {

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1048,7 +1048,7 @@ func (sc *SchedulerCache) deleteJob(job *schedulingapi.JobInfo) {
 }
 
 func (sc *SchedulerCache) retryDeleteJob(job *schedulingapi.JobInfo) {
-	klog.V(3).Infof("Retry to delete Job <%v:%v/%v>", job.UID, job.Namespace, job.Name)
+	klog.V(4).Infof("Retry to delete Job <%v:%v/%v>", job.UID, job.Namespace, job.Name)
 
 	sc.DeletedJobs.AddRateLimited(job)
 }

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1017,13 +1017,13 @@ func (sc *SchedulerCache) taskUnschedulable(task *schedulingapi.TaskInfo, reason
 		pod = pod.DeepCopy()
 
 		if updateCond && podutil.UpdatePodCondition(&pod.Status, condition) {
-			klog.V(3).Infof("Updating pod condition for %s/%s to (%s==%s)", pod.Namespace, pod.Name, condition.Type, condition.Status)
+			klog.V(4).Infof("Updating pod condition for %s/%s to (%s==%s)", pod.Namespace, pod.Name, condition.Type, condition.Status)
 		}
 
 		// if nominatedNode field changed, we should update it to the pod status, for k8s
 		// autoscaler will check this field and ignore this pod when scale up.
 		if updateNomiNode {
-			klog.V(3).Infof("Updating pod nominatedNodeName for %s/%s from (%s) to (%s)", pod.Namespace, pod.Name, pod.Status.NominatedNodeName, nominatedNodeName)
+			klog.V(4).Infof("Updating pod nominatedNodeName for %s/%s from (%s) to (%s)", pod.Namespace, pod.Name, pod.Status.NominatedNodeName, nominatedNodeName)
 			pod.Status.NominatedNodeName = nominatedNodeName
 		}
 

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -272,7 +272,7 @@ func (sc *SchedulerCache) syncTask(oldTask *schedulingapi.TaskInfo) error {
 				klog.Errorf("Failed to delete Pod <%v/%v> and remove from cache: %s", oldTask.Namespace, oldTask.Name, err.Error())
 				return err
 			}
-			klog.V(3).Infof("Pod <%v/%v> was deleted, removed from cache.", oldTask.Namespace, oldTask.Name)
+			klog.V(4).Infof("Pod <%v/%v> was deleted, removed from cache.", oldTask.Namespace, oldTask.Name)
 
 			return nil
 		}
@@ -367,7 +367,7 @@ func (sc *SchedulerCache) deletePod(pod *v1.Pod) error {
 		}
 	}
 	if err := sc.deleteTask(task); err != nil {
-		klog.Warningf("Failed to delete task: %v", err)
+		klog.V(4).Infof("Failed to delete task: %v", err)
 	}
 
 	// If job was terminated, delete it.
@@ -395,7 +395,7 @@ func (sc *SchedulerCache) AddPod(obj interface{}) {
 			pod.Namespace, pod.Name, err)
 		return
 	}
-	klog.V(3).Infof("Added pod <%s/%v> into cache.", pod.Namespace, pod.Name)
+	klog.V(4).Infof("Added pod <%s/%v> into cache.", pod.Namespace, pod.Name)
 }
 
 // UpdatePod update pod to scheduler cache
@@ -450,7 +450,7 @@ func (sc *SchedulerCache) DeletePod(obj interface{}) {
 		return
 	}
 
-	klog.V(3).Infof("Deleted pod <%s/%v> from cache.", pod.Namespace, pod.Name)
+	klog.V(4).Infof("Deleted pod <%s/%v> from cache.", pod.Namespace, pod.Name)
 }
 
 // addNodeImageStates adds states of the images on given node to the given nodeInfo and update the imageStates in
@@ -610,7 +610,7 @@ func (sc *SchedulerCache) SyncNode(nodeName string) error {
 				return deleteErr
 			}
 
-			klog.V(3).Infof("Node <%s> was deleted, removed from cache.", nodeName)
+			klog.V(4).Infof("Node <%s> was deleted, removed from cache.", nodeName)
 			return nil
 		}
 		klog.Errorf("Failed to get node %s, error: %v", nodeName, err)

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -96,6 +96,9 @@ type Session struct {
 	RealNodesList             map[string][]*api.NodeInfo
 	HyperNodesReadyToSchedule bool
 
+	PreemptorJobOrderFn api.LessFn
+	PreempteeJobOrderFn api.LessFn
+
 	plugins             map[string]Plugin
 	eventHandlers       []*EventHandler
 	jobOrderFns         map[string]api.CompareFn

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -302,7 +302,7 @@ func (ssn *Session) Overused(queue *api.QueueInfo) bool {
 }
 
 // Preemptive invoke can preemptive function of the plugins
-func (ssn *Session) Preemptive(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
+func (ssn *Session) Preemptive(queue *api.QueueInfo, candidate *api.JobInfo) bool {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			of, found := ssn.preemptiveFns[plugin.Name]

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -50,6 +50,21 @@ type operation struct {
 	reason string
 }
 
+func (o *operation) String() string {
+	opName := func(o Operation) string {
+		switch o {
+		case Evict:
+			return "Evict"
+		case Pipeline:
+			return "Pipeline"
+		case Allocate:
+			return "Allocate"
+		}
+		return "Unknown"
+	}
+	return fmt.Sprintf("operation: %s, task: %s/%s, reason: %s", opName(o.name), o.task.Job, o.task.Name, o.reason)
+}
+
 // Statement structure
 type Statement struct {
 	operations []operation
@@ -316,7 +331,7 @@ func (s *Statement) Allocate(task *api.TaskInfo, nodeInfo *api.NodeInfo) (err er
 			task.Namespace, task.Name, hostname, len(errInfos))
 	} else {
 		// Update status in session
-		klog.V(3).Info("Allocating operations ...")
+		klog.V(4).Info("Allocating operations ...")
 		s.operations = append(s.operations, operation{
 			name: Allocate,
 			task: task,

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -179,7 +179,7 @@ func (s *Statement) Pipeline(task *api.TaskInfo, hostname string, evictionOccurr
 				task.Namespace, task.Name, hostname, s.ssn.UID, err)
 			errInfos = append(errInfos, err)
 		}
-		klog.V(4).Infof("After pipelined Task <%v/%v> to Node <%v>: idle <%v>, used <%v>, releasing <%v>",
+		klog.V(3).Infof("After pipelined Task <%v/%v> to Node <%v>: idle <%v>, used <%v>, releasing <%v>",
 			task.Namespace, task.Name, node.Name, node.Idle, node.Used, node.Releasing)
 	} else {
 		err := fmt.Errorf("Failed to find Node <%s> in Session <%s> index when pipeline.",

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -179,7 +179,7 @@ func (s *Statement) Pipeline(task *api.TaskInfo, hostname string, evictionOccurr
 				task.Namespace, task.Name, hostname, s.ssn.UID, err)
 			errInfos = append(errInfos, err)
 		}
-		klog.V(3).Infof("After pipelined Task <%v/%v> to Node <%v>: idle <%v>, used <%v>, releasing <%v>",
+		klog.V(4).Infof("After pipelined Task <%v/%v> to Node <%v>: idle <%v>, used <%v>, releasing <%v>",
 			task.Namespace, task.Name, node.Name, node.Idle, node.Used, node.Releasing)
 	} else {
 		err := fmt.Errorf("Failed to find Node <%s> in Session <%s> index when pipeline.",
@@ -234,7 +234,7 @@ func (s *Statement) UnPipeline(task *api.TaskInfo) error {
 			klog.Errorf("Failed to remove task <%v/%v> to node <%v> when unpipeline in Session <%v>: %v",
 				task.Namespace, task.Name, task.NodeName, s.ssn.UID, err)
 		}
-		klog.V(3).Infof("After unpipelined Task <%v/%v> to Node <%v>: idle <%v>, used <%v>, releasing <%v>",
+		klog.V(4).Infof("After unpipelined Task <%v/%v> to Node <%v>: idle <%v>, used <%v>, releasing <%v>",
 			task.Namespace, task.Name, node.Name, node.Idle, node.Used, node.Releasing)
 	} else {
 		klog.Errorf("Failed to find Node <%s> in Session <%s> index when unpipeline.",
@@ -390,7 +390,7 @@ func (s *Statement) unallocate(task *api.TaskInfo) error {
 
 // Discard operation for evict, pipeline and allocate
 func (s *Statement) Discard() {
-	klog.V(3).Info("Discarding operations ...")
+	klog.V(4).Info("Discarding operations ...")
 	for i := len(s.operations) - 1; i >= 0; i-- {
 		op := s.operations[i]
 		op.task.GenerateLastTxContext()
@@ -416,7 +416,7 @@ func (s *Statement) Discard() {
 
 // Commit operation for evict and pipeline
 func (s *Statement) Commit() {
-	klog.V(3).Info("Committing operations ...")
+	klog.V(4).Info("Committing operations ...")
 	for _, op := range s.operations {
 		op.task.ClearLastTxContext()
 		switch op.name {

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -58,6 +58,7 @@ type queueAttr struct {
 	queueID   api.QueueID
 	name      string
 	share     float64
+	priority  int32
 	ancestors []api.QueueID
 	children  map[api.QueueID]*queueAttr
 
@@ -152,19 +153,19 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		queue := obj.(*api.QueueInfo)
-		task := candidate.(*api.TaskInfo)
+		job := candidate.(*api.JobInfo)
 		if queue.Queue.Status.State != scheduling.QueueStateOpen {
-			klog.V(3).Infof("Queue <%s> current state: %s, is not open state, can not reclaim for <%s>.", queue.Name, queue.Queue.Status.State, task.Name)
+			klog.V(3).Infof("Queue <%s> current state: %s, is not open state, can not reclaim for <%s>.", queue.Name, queue.Queue.Status.State, job.Name)
 			return false
 		}
 		attr := cp.queueOpts[queue.UID]
 
-		futureUsed := attr.allocated.Clone().Add(task.Resreq)
-		overused := !futureUsed.LessEqualWithDimension(attr.deserved, task.Resreq)
+		futureUsed := attr.allocated.Clone().Add(job.TotalRequest)
+		overused := !futureUsed.LessEqualWithDimension(attr.deserved, job.TotalRequest)
 		metrics.UpdateQueueOverused(attr.name, overused)
 		if overused {
 			klog.V(3).Infof("Queue <%v> can not reclaim, deserved <%v>, allocated <%v>, share <%v>, requested <%v>",
-				queue.Name, attr.deserved, attr.allocated, attr.share, task.Resreq)
+				queue.Name, attr.deserved, attr.allocated, attr.share, job.TotalRequest)
 		}
 
 		// PreemptiveFn is the opposite of OverusedFn in proportion plugin cause as long as there is a one-dimensional
@@ -365,12 +366,96 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				event.Task.Namespace, event.Task.Name, event.Task.Resreq, attr.share)
 		},
 	})
+
+	ssn.PreempteeJobOrderFn = cp.preempteeJobOrder
+	ssn.PreemptorJobOrderFn = cp.preemptorJobOrder
 }
 
 func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
 	cp.totalResource = nil
 	cp.totalGuarantee = nil
 	cp.queueOpts = nil
+}
+
+func (cp *capacityPlugin) preempteeJobOrder(l, r interface{}) bool {
+	lJob := l.(*api.JobInfo)
+	rJob := r.(*api.JobInfo)
+
+	lvElasticReplicas := getElasticReplicas(lJob)
+	rvElasticReplicas := getElasticReplicas(rJob)
+
+	if lvElasticReplicas != rvElasticReplicas {
+		// this will be used as a LessThan function in building up the heap,
+		// so we need to return the opposite of the comparison to prioritize the job with more elastic replicas
+		return lvElasticReplicas > rvElasticReplicas
+	}
+
+	// when jobs have the same elastic replicas, we compare the queue priorities
+	lQueue := cp.queueOpts[lJob.Queue]
+	rQueue := cp.queueOpts[rJob.Queue]
+
+	if lQueue.priority != rQueue.priority {
+		return lQueue.priority < rQueue.priority
+	}
+
+	// when jobs have the same elastic replicas and queue priorities, we compare the queue overusage
+	lvOverusage := getQueueOverusage(lQueue)
+	rvOverusage := getQueueOverusage(rQueue)
+	if lvOverusage != rvOverusage {
+		// we want to prioritize the queue with more overusage
+		return lvOverusage > rvOverusage
+	}
+
+	// we compare the priorities of the jobs
+	if lJob.Priority != rJob.Priority {
+		return lJob.Priority < rJob.Priority
+	}
+
+	// compare the number of tasks in a job, and we prioritize the job with fewer tasks
+	lTasks := len(lJob.Tasks)
+	rTasks := len(rJob.Tasks)
+	if lTasks != rTasks {
+		return lTasks < rTasks
+	}
+
+	// lastly we compare the job creation timestamp
+	return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
+}
+
+func getQueueOverusage(queue *queueAttr) float64 {
+	allocatedGPUs := queue.allocated.Get("nvidia.com/gpu")
+	deservedGPUs := queue.deserved.Get("nvidia.com/gpu")
+	overusage := float64(allocatedGPUs-deservedGPUs) / float64(deservedGPUs)
+	if overusage < 0 {
+		return 0
+	}
+	return overusage
+}
+
+func getElasticReplicas(job *api.JobInfo) int {
+	elasticReplicas := len(job.Tasks) - int(job.TaskMinAvailableTotal)
+	if elasticReplicas < 0 {
+		return 0
+	}
+	return elasticReplicas
+}
+
+func (cp *capacityPlugin) preemptorJobOrder(l, r interface{}) bool {
+	lJob := l.(*api.JobInfo)
+	rJob := r.(*api.JobInfo)
+
+	lQueue := cp.queueOpts[lJob.Queue]
+	rQueue := cp.queueOpts[rJob.Queue]
+
+	if lQueue.priority != rQueue.priority {
+		return lQueue.priority > rQueue.priority
+	}
+
+	if lJob.Priority != rJob.Priority {
+		return lJob.Priority > rJob.Priority
+	}
+
+	return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
 }
 
 func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
@@ -388,8 +473,9 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		if _, found := cp.queueOpts[job.Queue]; !found {
 			queue := ssn.Queues[job.Queue]
 			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
+				queueID:  queue.UID,
+				name:     queue.Name,
+				priority: queue.Queue.Spec.Priority,
 
 				deserved:  api.NewResource(queue.Queue.Spec.Deserved),
 				allocated: api.EmptyResource(),

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -366,96 +366,12 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				event.Task.Namespace, event.Task.Name, event.Task.Resreq, attr.share)
 		},
 	})
-
-	ssn.PreempteeJobOrderFn = cp.preempteeJobOrder
-	ssn.PreemptorJobOrderFn = cp.preemptorJobOrder
 }
 
 func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
 	cp.totalResource = nil
 	cp.totalGuarantee = nil
 	cp.queueOpts = nil
-}
-
-func (cp *capacityPlugin) preempteeJobOrder(l, r interface{}) bool {
-	lJob := l.(*api.JobInfo)
-	rJob := r.(*api.JobInfo)
-
-	lvElasticReplicas := getElasticReplicas(lJob)
-	rvElasticReplicas := getElasticReplicas(rJob)
-
-	if lvElasticReplicas != rvElasticReplicas {
-		// this will be used as a LessThan function in building up the heap,
-		// so we need to return the opposite of the comparison to prioritize the job with more elastic replicas
-		return lvElasticReplicas > rvElasticReplicas
-	}
-
-	// when jobs have the same elastic replicas, we compare the queue priorities
-	lQueue := cp.queueOpts[lJob.Queue]
-	rQueue := cp.queueOpts[rJob.Queue]
-
-	if lQueue.priority != rQueue.priority {
-		return lQueue.priority < rQueue.priority
-	}
-
-	// when jobs have the same elastic replicas and queue priorities, we compare the queue overusage
-	lvOverusage := getQueueOverusage(lQueue)
-	rvOverusage := getQueueOverusage(rQueue)
-	if lvOverusage != rvOverusage {
-		// we want to prioritize the queue with more overusage
-		return lvOverusage > rvOverusage
-	}
-
-	// we compare the priorities of the jobs
-	if lJob.Priority != rJob.Priority {
-		return lJob.Priority < rJob.Priority
-	}
-
-	// compare the number of tasks in a job, and we prioritize the job with fewer tasks
-	lTasks := len(lJob.Tasks)
-	rTasks := len(rJob.Tasks)
-	if lTasks != rTasks {
-		return lTasks < rTasks
-	}
-
-	// lastly we compare the job creation timestamp
-	return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
-}
-
-func getQueueOverusage(queue *queueAttr) float64 {
-	allocatedGPUs := queue.allocated.Get("nvidia.com/gpu")
-	deservedGPUs := queue.deserved.Get("nvidia.com/gpu")
-	overusage := float64(allocatedGPUs-deservedGPUs) / float64(deservedGPUs)
-	if overusage < 0 {
-		return 0
-	}
-	return overusage
-}
-
-func getElasticReplicas(job *api.JobInfo) int {
-	elasticReplicas := len(job.Tasks) - int(job.TaskMinAvailableTotal)
-	if elasticReplicas < 0 {
-		return 0
-	}
-	return elasticReplicas
-}
-
-func (cp *capacityPlugin) preemptorJobOrder(l, r interface{}) bool {
-	lJob := l.(*api.JobInfo)
-	rJob := r.(*api.JobInfo)
-
-	lQueue := cp.queueOpts[lJob.Queue]
-	rQueue := cp.queueOpts[rJob.Queue]
-
-	if lQueue.priority != rQueue.priority {
-		return lQueue.priority > rQueue.priority
-	}
-
-	if lJob.Priority != rJob.Priority {
-		return lJob.Priority > rJob.Priority
-	}
-
-	return lJob.CreationTimestamp.Before(&rJob.CreationTimestamp)
 }
 
 func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {

--- a/pkg/scheduler/plugins/predicates/cache.go
+++ b/pkg/scheduler/plugins/predicates/cache.go
@@ -71,7 +71,7 @@ func (pc *predicateCache) PredicateWithCache(nodeName string, pod *v1.Pod) (bool
 func (pc *predicateCache) UpdateCache(nodeName string, pod *v1.Pod, fit bool) {
 	podTemplateUID := getPodTemplateUID(pod)
 	if podTemplateUID == "" {
-		klog.V(3).Infof("Don't find pod %s template uid", pod.Name)
+		klog.V(4).Infof("Don't find pod %s template uid", pod.Name)
 		return
 	}
 

--- a/pkg/scheduler/util/priority_queue.go
+++ b/pkg/scheduler/util/priority_queue.go
@@ -91,7 +91,6 @@ func (pq *priorityQueue) Less(i, j int) bool {
 		return i < j
 	}
 
-	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
 	return pq.lessFn(pq.items[i], pq.items[j])
 }
 


### PR DESCRIPTION
This PR refactors the `reclaim` action so jobs are considered as the scheduling unit instead of pods. The main changes lie in the following areas:
1. `pkg/scheduler/api/resource_info.go`: we ignore non GPU resources for any kind of resource comparison.
2. `pkg/scheduler/plugins/capacity/capacity.go`: we block `reclaim` when the currentAllocation + pendingJobRequest goes beyond deserved.
3. `pkg/scheduler/actions/reclaim/reclaim.go`: the main reclaim logic that got refactored.